### PR TITLE
feat: add Stage 3 data to epartogram view and improve print layout

### DIFF
--- a/src/app/dashboard/stage3/stage3.component.html
+++ b/src/app/dashboard/stage3/stage3.component.html
@@ -12,55 +12,56 @@
 
           <div *ngIf="loading" class="text-center p-4">Loading Stage 3 details...</div>
 
-          <div *ngIf="!loading" class="delivery-outcome mb-3">
-            <table class="table table-bordered bg-white mb-0">
-              <tbody>
-                <tr class="sr-only">
-                  <th scope="col">Field 1</th>
-                  <th scope="col">Field 2</th>
-                  <th scope="col">Field 3</th>
-                  <th scope="col">Field 4</th>
-                </tr>
-                <tr class="delivery-title-row">
-                  <td colspan="4">DELIVERY OUTCOME REPORT</td>
-                </tr>
-                <tr class="page-title-row">
-                  <td colspan="2"><span>Name:</span> {{ pinfo?.name | noValue:'NA' }}</td>
-                  <td colspan="2"><span>OpenMRS ID:</span> {{ pinfo?.openMrsId | noValue:'NA' }}</td>
-                </tr>
-                <tr>
-                  <td><span>Delivery Date:</span> {{ deliveryOutcome.deliveryDate }}</td>
-                  <td><span>Delivery Time:</span> {{ deliveryOutcome.deliveryTime }}</td>
-                  <td><span>Delivery Mode:</span> {{ deliveryOutcome.deliveryMode }}</td>
-                  <td><span>Placenta &amp; Membrane Delivery:</span> {{ deliveryOutcome.placentaMembraneDelivery }}</td>
-                </tr>
-                <tr>
-                  <td><span>Placenta Delivery Time:</span> {{ deliveryOutcome.placentaDeliveryTime }}</td>
-                  <td><span>Placenta/Cord Abnormality:</span> {{ deliveryOutcome.placentaCordAbnormality }}</td>
-                  <td><span>Perineal Laceration:</span> {{ deliveryOutcome.perinealLaceration }}</td>
-                  <td><span>Degree of Tear:</span> {{ deliveryOutcome.degreeOfTear }}</td>
-                </tr>
-                <tr>
-                  <td class="amtsl-medication-cell"><span>AMTSL Medication:</span> {{ deliveryOutcome.amtslMedication }}</td>
-                  <td><span>Baby Status:</span> {{ deliveryOutcome.babyStatus }}</td>
-                  <td><span>Baby Gender:</span> {{ deliveryOutcome.babyGender }}</td>
-                  <td><span>Baby Weight (in grams):</span> {{ deliveryOutcome.babyWeight }}</td>
-                </tr>
-                <tr>
-                  <td><span>APGAR Score:</span> {{ deliveryOutcome.apgarScore }}</td>
-                  <td><span>Resuscitation:</span> {{ deliveryOutcome.resuscitation }}</td>
-                  <td><span>Skin-to-Skin:</span> {{ deliveryOutcome.skinToSkin }}</td>
-                  <td><span>Breast-feeding (in 1 hour):</span> {{ deliveryOutcome.breastfeedingInOneHour }}</td>
-                </tr>
-                <tr *ngIf="deliveryOutcome.congenitalDisorders !== '-'">
-                  <td colspan="4"><span>Congenital Disorders:</span> {{ deliveryOutcome.congenitalDisorders }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <div *ngIf="!loading" id="stage3-print-content">
+            <div class="delivery-outcome mb-3">
+              <table class="table table-bordered bg-white mb-0">
+                <tbody>
+                  <tr class="sr-only">
+                    <th scope="col">Field 1</th>
+                    <th scope="col">Field 2</th>
+                    <th scope="col">Field 3</th>
+                    <th scope="col">Field 4</th>
+                  </tr>
+                  <tr class="delivery-title-row">
+                    <td colspan="4">DELIVERY OUTCOME REPORT</td>
+                  </tr>
+                  <tr class="page-title-row">
+                    <td colspan="2"><span>Name:</span> {{ pinfo?.name | noValue:'NA' }}</td>
+                    <td colspan="2"><span>OpenMRS ID:</span> {{ pinfo?.openMrsId | noValue:'NA' }}</td>
+                  </tr>
+                  <tr>
+                    <td><span>Delivery Date:</span> {{ deliveryOutcome.deliveryDate }}</td>
+                    <td><span>Delivery Time:</span> {{ deliveryOutcome.deliveryTime }}</td>
+                    <td><span>Delivery Mode:</span> {{ deliveryOutcome.deliveryMode }}</td>
+                    <td><span>Placenta &amp; Membrane Delivery:</span> {{ deliveryOutcome.placentaMembraneDelivery }}</td>
+                  </tr>
+                  <tr>
+                    <td><span>Placenta Delivery Time:</span> {{ deliveryOutcome.placentaDeliveryTime }}</td>
+                    <td><span>Placenta/Cord Abnormality:</span> {{ deliveryOutcome.placentaCordAbnormality }}</td>
+                    <td><span>Perineal Laceration:</span> {{ deliveryOutcome.perinealLaceration }}</td>
+                    <td><span>Degree of Tear:</span> {{ deliveryOutcome.degreeOfTear }}</td>
+                  </tr>
+                  <tr>
+                    <td class="amtsl-medication-cell"><span>AMTSL Medication:</span> {{ deliveryOutcome.amtslMedication }}</td>
+                    <td><span>Baby Status:</span> {{ deliveryOutcome.babyStatus }}</td>
+                    <td><span>Baby Gender:</span> {{ deliveryOutcome.babyGender }}</td>
+                    <td><span>Baby Weight (in grams):</span> {{ deliveryOutcome.babyWeight }}</td>
+                  </tr>
+                  <tr>
+                    <td><span>APGAR Score:</span> {{ deliveryOutcome.apgarScore }}</td>
+                    <td><span>Resuscitation:</span> {{ deliveryOutcome.resuscitation }}</td>
+                    <td><span>Skin-to-Skin:</span> {{ deliveryOutcome.skinToSkin }}</td>
+                    <td><span>Breast-feeding (in 1 hour):</span> {{ deliveryOutcome.breastfeedingInOneHour }}</td>
+                  </tr>
+                  <tr *ngIf="deliveryOutcome.congenitalDisorders !== '-'">
+                    <td colspan="4"><span>Congenital Disorders:</span> {{ deliveryOutcome.congenitalDisorders }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
 
-          <div *ngIf="!loading" class="table-responsive" style="overflow-x: auto; cursor: grab;">
-            <table id="stage3-print-table" class="table table-bordered bg-white stage3-table">
+            <div class="table-responsive" style="overflow-x: auto; cursor: grab;">
+              <table id="stage3-print-table" class="table table-bordered bg-white stage3-table">
               <tbody>
                 <tr class="sr-only">
                   <th scope="col" colspan="2">Parameter</th>
@@ -125,7 +126,8 @@
                   </tr>
                 </ng-container>
               </tbody>
-            </table>
+              </table>
+            </div>
           </div>
 
           <div class="intel-card mt-4">

--- a/src/app/dashboard/stage3/stage3.component.ts
+++ b/src/app/dashboard/stage3/stage3.component.ts
@@ -739,8 +739,8 @@ export class Stage3Component implements OnInit {
   }
 
   printStage3() {
-    const tableEl = document.getElementById('stage3-print-table');
-    if (!tableEl) { globalThis.print(); return; }
+    const printContent = document.getElementById('stage3-print-content');
+    if (!printContent) { globalThis.print(); return; }
     const printWindow = globalThis.open('', '_blank', 'width=1400,height=900');
     if (!printWindow) { globalThis.print(); return; }
     const css = [
@@ -748,6 +748,9 @@ export class Stage3Component implements OnInit {
       'body { margin: 0; padding: 8px; font-family: Arial, sans-serif; }',
       'table { border-collapse: collapse; }',
       'th, td { border: 1px solid #000; padding: 5px 7px; font-size: 11px; text-align: center; vertical-align: middle; white-space: nowrap; }',
+      '.delivery-outcome { margin-bottom: 12px; }',
+      '.page-title-row td, .delivery-title-row td { font-weight: bold; }',
+      'td span { font-weight: bold; }',
       '.section-header-row td { background: #c8e6c9; font-weight: bold; text-align: left; }',
       'td.param-label { text-align: left; min-width: 160px; font-weight: bold; }',
       '.obs-chip { background: #e3f2fd; border-radius: 3px; padding: 1px 3px; margin: 1px; display: inline-block; }',
@@ -757,7 +760,7 @@ export class Stage3Component implements OnInit {
     doc.open();
     doc.close();
     doc.head.innerHTML = '<meta charset="utf-8"><title>Early PostPartum Monitoring Report</title><style>' + css + '</style>';
-    doc.body.innerHTML = '<table>' + tableEl.innerHTML + '</table>';
+    doc.body.innerHTML = printContent.innerHTML;
     setTimeout(() => {
       printWindow.focus();
       printWindow.print();

--- a/src/app/epartogram/epartogram.component.html
+++ b/src/app/epartogram/epartogram.component.html
@@ -1218,6 +1218,107 @@
             </div>
           </div>
 
+          <div class="intel-card mt-5" *ngIf="isNepalClient && hasStage3Data">
+            <div class="card-header">
+              <h6 class="mb-0">Stage 3 - Early Postpartum Monitoring</h6>
+            </div>
+            <div class="card-body bg-white">
+              <div class="table-responsive mb-3">
+                <table class="table table-bordered mb-0">
+                  <tbody>
+                    <tr class="page-title-row">
+                      <td colspan="4"><span>DELIVERY OUTCOME REPORT</span></td>
+                    </tr>
+                    <tr>
+                      <td><span>Delivery Date:</span> {{ stage3DeliveryOutcome.deliveryDate }}</td>
+                      <td><span>Delivery Time:</span> {{ stage3DeliveryOutcome.deliveryTime }}</td>
+                      <td><span>Delivery Mode:</span> {{ stage3DeliveryOutcome.deliveryMode }}</td>
+                      <td><span>Placenta &amp; Membrane Delivery:</span> {{ stage3DeliveryOutcome.placentaMembraneDelivery }}</td>
+                    </tr>
+                    <tr>
+                      <td><span>Placenta Delivery Time:</span> {{ stage3DeliveryOutcome.placentaDeliveryTime }}</td>
+                      <td><span>Placenta/Cord Abnormality:</span> {{ stage3DeliveryOutcome.placentaCordAbnormality }}</td>
+                      <td><span>Perineal Laceration:</span> {{ stage3DeliveryOutcome.perinealLaceration }}</td>
+                      <td><span>Degree of Tear:</span> {{ stage3DeliveryOutcome.degreeOfTear }}</td>
+                    </tr>
+                    <tr>
+                      <td><span>AMTSL Medication:</span> {{ stage3DeliveryOutcome.amtslMedication }}</td>
+                      <td><span>Baby Status:</span> {{ stage3DeliveryOutcome.babyStatus }}</td>
+                      <td><span>Baby Gender:</span> {{ stage3DeliveryOutcome.babyGender }}</td>
+                      <td><span>Baby Weight:</span> {{ stage3DeliveryOutcome.babyWeight }}</td>
+                    </tr>
+                    <tr>
+                      <td><span>APGAR Score:</span> {{ stage3DeliveryOutcome.apgarScore }}</td>
+                      <td><span>Resuscitation:</span> {{ stage3DeliveryOutcome.resuscitation }}</td>
+                      <td><span>Skin-to-Skin:</span> {{ stage3DeliveryOutcome.skinToSkin }}</td>
+                      <td><span>Breast-feeding (in 1 hour):</span> {{ stage3DeliveryOutcome.breastfeedingInOneHour }}</td>
+                    </tr>
+                    <tr *ngIf="stage3DeliveryOutcome.congenitalDisorders !== '-'">
+                      <td colspan="4"><span>Congenital Disorders:</span> {{ stage3DeliveryOutcome.congenitalDisorders }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-bordered mb-0">
+                  <tbody>
+                    <tr class="page-title-row">
+                      <td colspan="10"><span>MOTHER CONDITION</span></td>
+                    </tr>
+                    <tr>
+                      <td><span>Parameter</span></td>
+                      <ng-container *ngFor="let idx of stage3ColIndexes">
+                        <td>
+                          <div>{{ stage3ColLabels[idx] }}</div>
+                          <small *ngIf="stage3ColTimes[idx]" class="text-muted">{{formatDateByClient(stage3ColTimes[idx])}} {{stage3ColTimes[idx] | date:'HH:mm'}}</small>
+                        </td>
+                      </ng-container>
+                    </tr>
+                    <ng-container *ngFor="let p of stage3MaternalParams">
+                      <tr *ngIf="!p.isTextarea">
+                        <td><span>{{ p.name }}</span></td>
+                        <ng-container *ngFor="let idx of stage3ColIndexes">
+                          <td>{{ p.values[idx]?.value || '-' }}</td>
+                        </ng-container>
+                      </tr>
+                      <tr *ngIf="p.isTextarea">
+                        <td><span>{{ p.name }}</span></td>
+                        <ng-container *ngFor="let idx of stage3ColIndexes">
+                          <td>
+                            <div *ngFor="let ob of p.values[idx]">{{ ob.initial }} {{ ob.value }}</div>
+                            <div *ngIf="!p.values[idx]?.length">-</div>
+                          </td>
+                        </ng-container>
+                      </tr>
+                    </ng-container>
+
+                    <tr class="page-title-row">
+                      <td colspan="10"><span>NEWBORN CONDITION</span></td>
+                    </tr>
+                    <ng-container *ngFor="let p of stage3NewbornParams">
+                      <tr *ngIf="!p.isTextarea">
+                        <td><span>{{ p.name }}</span></td>
+                        <ng-container *ngFor="let idx of stage3ColIndexes">
+                          <td>{{ p.values[idx]?.value || '-' }}</td>
+                        </ng-container>
+                      </tr>
+                      <tr *ngIf="p.isTextarea">
+                        <td><span>{{ p.name }}</span></td>
+                        <ng-container *ngFor="let idx of stage3ColIndexes">
+                          <td>
+                            <div *ngFor="let ob of p.values[idx]">{{ ob.initial }} {{ ob.value }}</div>
+                            <div *ngIf="!p.values[idx]?.length">-</div>
+                          </td>
+                        </ng-container>
+                      </tr>
+                    </ng-container>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
         </div>
       </div>
     </div>

--- a/src/app/epartogram/epartogram.component.ts
+++ b/src/app/epartogram/epartogram.component.ts
@@ -11,6 +11,16 @@ import { AuthService } from '../services/auth.service';
 import { NepaliDateService } from 'src/app/core/services/nepali-date.service';
 import { environment } from 'src/environments/environment';
 
+const STAGE3_COL_LABELS = ['0 min', '+15m', '+30m', '+45m', '+1h 15m', '+1h 45m', '+2h 45m', '+3h 45m'];
+const STAGE3_NUM_COLS = STAGE3_COL_LABELS.length;
+
+interface EPartogramStage3Param {
+  name: string;
+  conceptName: string;
+  isTextarea?: boolean;
+  values: any[];
+}
+
 @Component({
   selector: 'app-epartogram',
   templateUrl: './epartogram.component.html',
@@ -34,6 +44,57 @@ export class EpartogramComponent implements OnInit {
   birthtime: string;
   visitCompleted: boolean = false;
   assessments: any[] = [];
+  hasStage3Data = false;
+  stage3DeliveryOutcome = {
+    deliveryDate: '-',
+    deliveryTime: '-',
+    deliveryMode: '-',
+    placentaMembraneDelivery: '-',
+    placentaDeliveryTime: '-',
+    amtslMedication: '-',
+    babyStatus: '-',
+    babyGender: '-',
+    babyWeight: '-',
+    apgarScore: '-',
+    resuscitation: '-',
+    skinToSkin: '-',
+    breastfeedingInOneHour: '-',
+    placentaCordAbnormality: '-',
+    perinealLaceration: '-',
+    degreeOfTear: '-',
+    congenitalDisorders: '-',
+  };
+  stage3ColLabels = STAGE3_COL_LABELS;
+  stage3NumCols = STAGE3_NUM_COLS;
+  stage3ColIndexes = Array.from({ length: STAGE3_NUM_COLS }, (_, i) => i);
+  stage3ColTimes: (string | null)[] = new Array(STAGE3_NUM_COLS).fill(null);
+
+  stage3MaternalParams: EPartogramStage3Param[] = [
+    { name: 'Pulse',               conceptName: 'PULSE',             values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'BP',                  conceptName: 'Systolic BP',       values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Respiratory Rate',    conceptName: 'Respiratory Rate',  values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Temperature',         conceptName: 'TEMPERATURE (C)',   values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Blood Loss',          conceptName: 'Blood Loss',        values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Uterus Contracted',   conceptName: 'Uterus Contracted', values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Urine Passed',        conceptName: 'Urine Passed',      values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Hematoma',            conceptName: 'Hematoma',          values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Complication',        conceptName: 'Complication',      values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Assessment (Mother)', conceptName: 'Assessment Mother', isTextarea: true, values: new Array(STAGE3_NUM_COLS).fill(null).map(() => []) },
+    { name: 'Plan (Mother)',       conceptName: 'Plan Mother',       isTextarea: true, values: new Array(STAGE3_NUM_COLS).fill(null).map(() => []) },
+  ];
+
+  stage3NewbornParams: EPartogramStage3Param[] = [
+    { name: 'Grunting',              conceptName: 'Grunting',              values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Chest Indrawing',       conceptName: 'Chest Indrawing',       values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Fast Breathing',        conceptName: 'Fast Breathing',        values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Feet Temperature',      conceptName: 'Feet Temperature',      values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Skin Color',            conceptName: 'Skin Color',            values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Umbilical Cord Oozing', conceptName: 'Umbilical Cord Oozing', values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Sucking / Feeding',     conceptName: 'Sucking Feeding',       values: new Array(STAGE3_NUM_COLS).fill(null) },
+    { name: 'Assessment (Newborn)',  conceptName: 'Assessment Newborn',    isTextarea: true, values: new Array(STAGE3_NUM_COLS).fill(null).map(() => []) },
+    { name: 'Plan (Newborn)',        conceptName: 'Plan Newborn',          isTextarea: true, values: new Array(STAGE3_NUM_COLS).fill(null).map(() => []) },
+  ];
+
   parameters: any[] = [
     {
       name: 'Companion',
@@ -406,8 +467,255 @@ export class EpartogramComponent implements OnInit {
         this.patient = visit?.patient;
         this.readPatientAttributes();
         this.readStageData();
+        this.readStage3Data();
       }
     });
+  }
+
+  private readStage3Data() {
+    this.resetStage3Grid();
+    const encounters = this.visit?.encounters || [];
+    const deliveryOutcomeEncounter = encounters.find((encounter: any) => encounter.encounterType?.display === 'DELIVERY_OUTCOME_STAGE3');
+    const stage3Encounters = encounters.filter((e: any) => /^Stage3_Hour\d+(?:_\d+)?$/.test(e.encounterType?.display));
+    this.hasStage3Data = !!deliveryOutcomeEncounter || stage3Encounters.length > 0;
+    if (!this.hasStage3Data) {
+      return;
+    }
+
+    this.readStage3DeliveryOutcome(deliveryOutcomeEncounter);
+    this.readStage3GridData(stage3Encounters);
+  }
+
+  private resetStage3Grid() {
+    this.stage3ColTimes = new Array(STAGE3_NUM_COLS).fill(null);
+    this.stage3MaternalParams.forEach((p: EPartogramStage3Param) => {
+      p.values = p.isTextarea ? new Array(STAGE3_NUM_COLS).fill(null).map(() => []) : new Array(STAGE3_NUM_COLS).fill(null);
+    });
+    this.stage3NewbornParams.forEach((p: EPartogramStage3Param) => {
+      p.values = p.isTextarea ? new Array(STAGE3_NUM_COLS).fill(null).map(() => []) : new Array(STAGE3_NUM_COLS).fill(null);
+    });
+  }
+
+  private getObsValueByConcept(encounter: any, conceptDisplays: string[]): any {
+    const obs = (encounter?.obs || []).find((item: any) => conceptDisplays.includes(item?.concept?.display));
+    return obs?.value;
+  }
+
+  private toDisplayText(value: any): string {
+    if (value === undefined || value === null || value === '') {
+      return '-';
+    }
+    return String(value);
+  }
+
+  private formatTimeValue(value: any): string {
+    if (value === undefined || value === null || value === '') {
+      return '-';
+    }
+    const parsed = moment(value, [moment.ISO_8601, 'HH:mm', 'hh:mm A', 'hh:mm a'], true);
+    if (!parsed.isValid()) {
+      return this.toDisplayText(value);
+    }
+    return parsed.format('hh:mm A');
+  }
+
+  private formatAmtslMedication(value: any): string {
+    if (value === undefined || value === null || value === '') {
+      return '-';
+    }
+    let normalized = value;
+    if (typeof normalized === 'string') {
+      const raw = normalized.trim();
+      if (raw.startsWith('{') || raw.startsWith('[')) {
+        try {
+          normalized = JSON.parse(raw);
+        } catch {
+          return raw;
+        }
+      }
+    }
+    if (Array.isArray(normalized)) {
+      return normalized.map(String).filter(Boolean).join(', ');
+    }
+    if (typeof normalized === 'object') {
+      return this.toDisplayText(normalized.MEDICATIONS_AMTSL || normalized.Medications_AMTSL || normalized['AMTSL Medication']);
+    }
+    return this.toDisplayText(normalized);
+  }
+
+  private formatCongenitalDisorders(value: any): string {
+    if (value === undefined || value === null || value === '') {
+      return '-';
+    }
+    let normalized = value;
+    if (typeof normalized === 'string') {
+      const raw = normalized.trim();
+      if (raw.startsWith('{') || raw.startsWith('[')) {
+        try {
+          normalized = JSON.parse(raw);
+        } catch {
+          return raw;
+        }
+      }
+    }
+    if (Array.isArray(normalized)) {
+      return normalized.map(String).filter(Boolean).join(', ');
+    }
+    if (typeof normalized === 'object') {
+      const disorders: string[] = [];
+      const congenitalArray = normalized.CONGENITAL_ANOMALY || normalized.congenital_anomaly || [];
+      if (Array.isArray(congenitalArray)) {
+        disorders.push(...congenitalArray.map(String).filter(Boolean));
+      }
+      if (normalized.other_text) {
+        disorders.push(String(normalized.other_text));
+      }
+      return disorders.length ? disorders.join(', ') : '-';
+    }
+    return this.toDisplayText(normalized);
+  }
+
+  private readStage3DeliveryOutcome(sourceEncounter: any) {
+    if (!sourceEncounter) {
+      return;
+    }
+
+    const deliveryDateObs = this.getObsValueByConcept(sourceEncounter, ['Delivery Date', 'DATE OF DELIVERY', 'Birth Date', 'DELIVERY_DATE']);
+    const deliveryTimeObs = this.getObsValueByConcept(sourceEncounter, ['Delivery Time', 'TIME OF DELIVERY', 'Birth Time', 'DELIVERY_TIME']);
+    const fallbackDateTime = sourceEncounter?.encounterDatetime;
+    const apgar1 = this.getObsValueByConcept(sourceEncounter, ['Apgar at 1 min']);
+    const apgar5 = this.getObsValueByConcept(sourceEncounter, ['Apgar at 5 min']);
+
+    this.stage3DeliveryOutcome.deliveryDate = this.formatDateByClient(deliveryDateObs || fallbackDateTime) || '-';
+    this.stage3DeliveryOutcome.deliveryTime = this.formatTimeValue(deliveryTimeObs || fallbackDateTime);
+    this.stage3DeliveryOutcome.deliveryMode = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Delivery Mode', 'Mode of Delivery', 'DELIVERY_MODE']));
+    this.stage3DeliveryOutcome.placentaMembraneDelivery = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Placenta & Membrane Delivery', 'Placenta and Membrane Delivery', 'PLACENTA_MEMBRANE_STATUS']));
+    this.stage3DeliveryOutcome.placentaDeliveryTime = this.formatTimeValue(this.getObsValueByConcept(sourceEncounter, ['Placenta Delivery Time', 'PLACENTA_DELIVERY_TIME']));
+    this.stage3DeliveryOutcome.amtslMedication = this.formatAmtslMedication(this.getObsValueByConcept(sourceEncounter, ['AMTSL Medication', 'AMTSL', 'Medications_AMTSL']));
+    this.stage3DeliveryOutcome.babyStatus = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Baby status', 'Baby Status', 'BIRTH_TYPE']));
+    this.stage3DeliveryOutcome.babyGender = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Sex', 'Baby Gender']));
+    this.stage3DeliveryOutcome.babyWeight = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['BirthWeight', 'Baby Weight']));
+    this.stage3DeliveryOutcome.apgarScore = (apgar1 || apgar5) ? `${this.toDisplayText(apgar1)}/${this.toDisplayText(apgar5)}` : '-';
+    this.stage3DeliveryOutcome.resuscitation = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Resuscitation', 'RESUSCITATION']));
+    this.stage3DeliveryOutcome.skinToSkin = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Skin-to-skin', 'Skin To Skin', 'Skin-to skin contact', 'Skin-to skin contact']));
+    this.stage3DeliveryOutcome.breastfeedingInOneHour = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Breast-feeding in 1 hour', 'Breastfeeding in 1 hour', 'BREASTFED_FIRSTHOUR']));
+    this.stage3DeliveryOutcome.placentaCordAbnormality = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Placenta or cord abnormality']));
+    this.stage3DeliveryOutcome.perinealLaceration = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['Perineal laceration during delivery']));
+    this.stage3DeliveryOutcome.degreeOfTear = this.toDisplayText(this.getObsValueByConcept(sourceEncounter, ['DEGREE_OF_TEAR', 'Degree of tear']));
+    this.stage3DeliveryOutcome.congenitalDisorders = this.formatCongenitalDisorders(this.getObsValueByConcept(sourceEncounter, ['CONGENITAL DISORDERS', 'Congenital Disorders']));
+  }
+
+  private stage3NormalizeConcept(value: any): string {
+    return String(value || '').trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  }
+
+  private stage3GetParamAliases(section: 'maternal' | 'newborn', param: EPartogramStage3Param): string[] {
+    const aliases: string[] = [param?.conceptName, param?.name];
+
+    if (section === 'maternal') {
+      if (param.name === 'BP') {
+        aliases.push('Systolic BP', 'Diastolic BP');
+      } else if (param.name === 'Respiratory Rate') {
+        aliases.push('Respiratory rate');
+      } else if (param.name === 'Blood Loss') {
+        aliases.push('BLOOD_LOSS_MOTHER', 'Blood Loss Mother');
+      } else if (param.name === 'Uterus Contracted') {
+        aliases.push('UTERUS_CONTRACTED_MOTHER');
+      } else if (param.name === 'Urine Passed') {
+        aliases.push('URINE_PASSED_MOTHER');
+      } else if (param.name === 'Hematoma') {
+        aliases.push('HEMATOMA_MOTHER');
+      } else if (param.name === 'Complication') {
+        aliases.push('ONGOING_COMPLICATIONS_MOTHER', 'Complications Mother');
+      } else if (param.name === 'Assessment (Mother)') {
+        aliases.push('ASSESSMENT_MOTHER', 'Assessment Mother');
+      } else if (param.name === 'Plan (Mother)') {
+        aliases.push('PLAN_MOTHER', 'Plan Mother', 'Additional comments');
+      }
+    }
+
+    if (section === 'newborn') {
+      if (param.name === 'Grunting') {
+        aliases.push('GRUNTING_NEWBORN');
+      } else if (param.name === 'Chest Indrawing') {
+        aliases.push('CHEST_INDRAWING_NEWBORN');
+      } else if (param.name === 'Fast Breathing') {
+        aliases.push('FAST_BREATHING_NEWBORN');
+      } else if (param.name === 'Feet Temperature') {
+        aliases.push('FEET_WARM_NEWBORN', 'Feet Warm Newborn');
+      } else if (param.name === 'Skin Color') {
+        aliases.push('SKIN_COLOR_NEWBORN');
+      } else if (param.name === 'Umbilical Cord Oozing') {
+        aliases.push('UC_OOZING_NEWBORN', 'Umbilical Cord Oozing Newborn');
+      } else if (param.name === 'Sucking / Feeding') {
+        aliases.push('SUCKING_FEEDING_NEWBORN', 'Sucking Feeding Newborn');
+      } else if (param.name === 'Assessment (Newborn)') {
+        aliases.push('ASSESSMENT_NEWBORN', 'Assessment Newborn');
+      } else if (param.name === 'Plan (Newborn)') {
+        aliases.push('PLAN_NEWBORN', 'Plan Newborn');
+      }
+    }
+
+    return aliases
+      .map((item: string) => this.stage3NormalizeConcept(item))
+      .filter(Boolean);
+  }
+
+  private stage3MatchesParamObs(ob: any, param: EPartogramStage3Param, section: 'maternal' | 'newborn'): boolean {
+    const obsDisplay = this.stage3NormalizeConcept(ob?.concept?.display);
+    const aliases = this.stage3GetParamAliases(section, param);
+    return aliases.includes(obsDisplay);
+  }
+
+  private readStage3GridData(stage3Encounters: any[]) {
+    const encs = stage3Encounters
+      .sort((a: any, b: any) => new Date(a.encounterDatetime).getTime() - new Date(b.encounterDatetime).getTime())
+      .slice(0, STAGE3_NUM_COLS);
+
+    for (const [encIndex, enc] of encs.entries()) {
+      const colIndex = encIndex;
+      this.stage3ColTimes[colIndex] = enc.encounterDatetime;
+
+      for (const ob of (enc.obs || [])) {
+        let idx = this.stage3MaternalParams.findIndex((param: EPartogramStage3Param) => this.stage3MatchesParamObs(ob, param, 'maternal'));
+        if (idx >= 0) {
+          const p = this.stage3MaternalParams[idx];
+          if (p.isTextarea) {
+            if (!Array.isArray(p.values[colIndex])) {
+              p.values[colIndex] = [];
+            }
+            const displayName = ob.creator?.person?.display;
+            const initial = displayName && displayName.includes(' ') ? this.getInitials(displayName) : '';
+            p.values[colIndex] = [...p.values[colIndex], { value: ob.value, initial }];
+          } else if (p.name === 'BP') {
+            const concept = this.stage3NormalizeConcept(ob?.concept?.display);
+            const current = p.values[colIndex]?.value ? String(p.values[colIndex].value) : '';
+            const systolic = /systolicbp/.test(concept) ? String(ob.value) : (current.includes('/') ? current.split('/')[0] : current);
+            const diastolic = /diastolicbp/.test(concept) ? String(ob.value) : (current.includes('/') ? current.split('/')[1] : '');
+            const value = systolic && diastolic ? `${systolic}/${diastolic}` : (systolic || diastolic);
+            p.values[colIndex] = { value };
+          } else {
+            p.values[colIndex] = { value: ob.value };
+          }
+          continue;
+        }
+
+        idx = this.stage3NewbornParams.findIndex((param: EPartogramStage3Param) => this.stage3MatchesParamObs(ob, param, 'newborn'));
+        if (idx >= 0) {
+          const p = this.stage3NewbornParams[idx];
+          if (p.isTextarea) {
+            if (!Array.isArray(p.values[colIndex])) {
+              p.values[colIndex] = [];
+            }
+            const displayName = ob.creator?.person?.display;
+            const initial = displayName && displayName.includes(' ') ? this.getInitials(displayName) : '';
+            p.values[colIndex] = [...p.values[colIndex], { value: ob.value, initial }];
+          } else {
+            p.values[colIndex] = { value: ob.value };
+          }
+        }
+      }
+    }
   }
 
   readPatientAttributes() {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,18 @@
-// ─── Change this one line before building for a client ──────────────────────
-const CLIENT = 'nepal' as 'ezazi' | 'nepal';
-// ─────────────────────────────────────────────────────────────────────────────
+const HOSTNAME = window.location.hostname.toLowerCase();
+const CLIENT: 'ezazi' | 'nepal' = HOSTNAME.includes('nezazi') ? 'nepal' : 'ezazi';
+
+const CAPTCHA_KEYS = {
+  ezazi: {
+    captchaSiteKey: '6LelRWAsAAAAAD-RkHB_lT9OT19I5ClAIHQzen7O',
+    siteKey: '6LelRWAsAAAAAD-RkHB_lT9OT19I5ClAIHQzen7O',
+  },
+  nepal: {
+    captchaSiteKey: '6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR',
+    siteKey: '6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR',
+  },
+};
+
+const { captchaSiteKey, siteKey } = CAPTCHA_KEYS[CLIENT];
 
 export const environment = {
   production: true,
@@ -16,8 +28,8 @@ export const environment = {
   gatewayURL:      `${window.location.protocol}//${window.location.hostname}:3030/`,
   webrtcSdkServerUrl:   `wss://${window.location.hostname}:9090`,
   webrtcTokenServerUrl: `${window.location.protocol}//${window.location.hostname}:3000/`,
- captchaSiteKey: "6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR",
-  siteKey:        "6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR",
+  captchaSiteKey,
+  siteKey,
   externalPrescriptionCred: 'ZXh0ZXJuYWxwcmVzdXNlcjpJSFVzZXIjMQ==',
   vapidPublicKey: "BM4tUVW1UwkMpfAWh2mwhA-wwdIC2rCF1MFypbFpjn23qYMQXaeAaYi6ydGslRb_Vdr2Ws0MW5RSUH9InEbYNhA",
   recordsPerPage: 50

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -11,7 +11,19 @@ const URLS = {
   nepal: 'https://nezazi.intelehealth.org',
 };
 
+const CAPTCHA_KEYS = {
+  ezazi: {
+    captchaSiteKey: '6LelRWAsAAAAAD-RkHB_lT9OT19I5ClAIHQzen7O',
+    siteKey: '6LelRWAsAAAAAD-RkHB_lT9OT19I5ClAIHQzen7O',
+  },
+  nepal: {
+    captchaSiteKey: '6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR',
+    siteKey: '6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR',
+  },
+};
+
 const base = URLS[CLIENT];
+const { captchaSiteKey, siteKey } = CAPTCHA_KEYS[CLIENT];
 
 export const environment = {
   production: false,
@@ -27,8 +39,8 @@ export const environment = {
   gatewayURL:      `${base}:3030/`,
   webrtcSdkServerUrl:   `wss://${new URL(base).hostname}:9090`,
   webrtcTokenServerUrl: `${base}:3000/`,
-  captchaSiteKey: "6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR",
-  siteKey:        "6LeiTrwsAAAAAEerPKTAyD505fwTYrkl70JYImCR",
+  captchaSiteKey,
+  siteKey,
   externalPrescriptionCred: 'ZXh0ZXJuYWxwcmVzdXNlcjpJSFVzZXIjMQ==',
   vapidPublicKey: "BM4tUVW1UwkMpfAWh2mwhA-wwdIC2rCF1MFypbFpjn23qYMQXaeAaYi6ydGslRb_Vdr2Ws0MW5RSUH9InEbYNhA",
   recordsPerPage: 50


### PR DESCRIPTION
- Display Stage 3 (Early Postpartum Monitoring) delivery outcome and
  maternal/newborn condition grid within the epartogram component for Nepal clients
- Wrap Stage 3 print content in a single container to include both
  delivery outcome table and monitoring grid in the print output
- Make captcha keys dynamic per client in environment configs instead
  of hardcoding Nepal keys
