### PR TITLE
fix: stage3 page should not require login (match epartogram behavior)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -20,6 +20,10 @@ const routes: Routes = [
     path: 'test/chat',
     component: TestChatComponent
   },
+  {
+    path: 'dashboard/stage3',
+    loadChildren: () => import('./dashboard/stage3/stage3.module').then(m => m.Stage3Module)
+  },
   // {
   //   path: 'i/:hash',
   //   loadChildren: () => import('./prescription-download/prescription-download.module').then(m => m.PrescriptionDownloadModule),

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -8,7 +8,6 @@ import { ProfileComponent } from './profile/profile.component';
 import { PartogramComponent } from './partogram/partogram.component';
 import { HwProfileComponent } from './hw-profile/hw-profile.component';
 import { NgxPermissionsGuard } from 'ngx-permissions';
-import { Stage3Component } from './stage3/stage3.component';
 
 const routes: Routes = [
   {
@@ -41,13 +40,6 @@ const routes: Routes = [
       breadcrumb: 'WHO LCG View'
     },
     component: PartogramComponent
-  },
-  {
-    path: 'stage3/:id',
-    data: {
-      breadcrumb: 'Stage 3'
-    },
-    component: Stage3Component
   },
   {
     path: 'change-password',

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -27,7 +27,6 @@ import { PartogramComponent } from './partogram/partogram.component';
 import { NgxPanZoomModule } from 'ngx-panzoom';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import { HwProfileComponent } from './hw-profile/hw-profile.component';
-import { Stage3Component } from './stage3/stage3.component';
 
 @NgModule({
   declarations: [
@@ -36,8 +35,7 @@ import { Stage3Component } from './stage3/stage3.component';
     GetStartedComponent,
     ChangePasswordComponent,
     PartogramComponent,
-    HwProfileComponent,
-    Stage3Component
+    HwProfileComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/dashboard/stage3/stage3-routing.module.ts
+++ b/src/app/dashboard/stage3/stage3-routing.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { Stage3Component } from './stage3.component';
+
+const routes: Routes = [{ path: ':id', component: Stage3Component }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class Stage3RoutingModule { }

--- a/src/app/dashboard/stage3/stage3.module.ts
+++ b/src/app/dashboard/stage3/stage3.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { Stage3RoutingModule } from './stage3-routing.module';
+import { Stage3Component } from './stage3.component';
+import { SharedModule } from '../../shared.module';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatIconModule } from '@angular/material/icon';
+
+@NgModule({
+  declarations: [Stage3Component],
+  imports: [
+    CommonModule,
+    FormsModule,
+    Stage3RoutingModule,
+    SharedModule,
+    MatExpansionModule,
+    MatIconModule
+  ]
+})
+export class Stage3Module { }


### PR DESCRIPTION
extract Stage3Component into its own lazy Stage3Module and register it
as a top-level route in app-routing, before the guarded parent. URL is
unchanged; route now bypasses RouteAuthGuard, mirroring how
/epartogram/:id works.