### PR TITLE
fix: stage3 + LCG UI improvements and make epartogram publicly accessible

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,6 +14,18 @@ export class AppComponent implements OnInit {
 
   ngOnInit() {
     document.body.classList.add(`client-${environment.client}`);
+    if (environment.client === 'nepal') {
+      document.title = 'NEzazi';
+      const favicon = document.querySelector('link[rel="icon"]') as HTMLLinkElement | null;
+      if (favicon) {
+        favicon.type = 'image/png';
+        favicon.href = '/assets/nepal/jhpiego-removebg-preview.png';
+      }
+      const apple = document.querySelector('link[rel="apple-touch-icon"]') as HTMLLinkElement | null;
+      if (apple) apple.href = '/assets/icons/nepal/icon-192x192-20260507.png';
+      const manifest = document.querySelector('link[rel="manifest"]') as HTMLLinkElement | null;
+      if (manifest) manifest.href = 'manifest.nepal.webmanifest?v=20260507';
+    }
     setTimeout(() => {
       this.showSplash = false;
     }, 1000);

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -188,11 +188,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     if (!this.isNepalClient) {
-      return moment(adDate).format('DD MMM, YYYY');
+      return moment(adDate).format('YYYY/MM/DD');
     }
 
     const bsDate = this.nepaliDateService.gregorianToBs(adDate);
-    return bsDate ? this.nepaliDateService.formatBsDate(bsDate) : moment(adDate).format('DD MMM, YYYY');
+    return bsDate
+      ? `${bsDate.year} ${this.nepaliDateService.monthNames[bsDate.month - 1]} ${String(bsDate.day).padStart(2, '0')}`
+      : moment(adDate).format('YYYY/MM/DD');
   }
 
   formatDateTimeByClient(dateValue: any): string {

--- a/src/app/dashboard/partogram/partogram.component.ts
+++ b/src/app/dashboard/partogram/partogram.component.ts
@@ -398,11 +398,13 @@ export class PartogramComponent implements OnInit, OnDestroy {
     }
 
     if (!this.isNepalClient) {
-      return moment(adDate).format('DD/MM/YYYY');
+      return moment(adDate).format('YYYY/MM/DD');
     }
 
     const bsDate = this.nepaliDateService.gregorianToBs(adDate);
-    return bsDate ? this.nepaliDateService.formatBsDate(bsDate) : moment(adDate).format('DD/MM/YYYY');
+    return bsDate
+      ? `${bsDate.year} ${this.nepaliDateService.monthNames[bsDate.month - 1]} ${String(bsDate.day).padStart(2, '0')}`
+      : moment(adDate).format('YYYY/MM/DD');
   }
 
   private parseIncomingDate(dateValue: any): Date | null {
@@ -1071,9 +1073,7 @@ export class PartogramComponent implements OnInit, OnDestroy {
   }
 
   getInitials(name: string) {
-    const fullName = name.split(' ');
-    const initials = fullName.shift().charAt(0) + fullName.pop().charAt(0);
-    return initials.toUpperCase();
+    return name ? name.trim() : '';
   }
 
   async startCall() {

--- a/src/app/dashboard/stage3/stage3.component.html
+++ b/src/app/dashboard/stage3/stage3.component.html
@@ -76,7 +76,17 @@
                   <tr *ngIf="!p.isTextarea">
                     <td class="param-label" colspan="2">{{ p.name }}</td>
                     <ng-container *ngFor="let idx of colIndexes">
-                      <td><div class="value-item" [class.alert-value]="isAlert(p.name, p.values[idx]?.value)" *ngIf="p.values[idx]">{{ p.values[idx]?.value }}</div></td>
+                      <td>
+                        <ng-container *ngIf="p.values[idx]">
+                          <div class="value-item" [class.alert-value]="isAlert(p.name, p.values[idx]?.value)">
+                            <ng-container *ngIf="p.name === 'BP'; else plainBpValue">
+                              <div *ngIf="getBpPart(p.values[idx]?.value, 'systolic') as s">Systolic: {{ s }}</div>
+                              <div *ngIf="getBpPart(p.values[idx]?.value, 'diastolic') as d">Diastolic: {{ d }}</div>
+                            </ng-container>
+                            <ng-template #plainBpValue>{{ p.values[idx]?.value }}</ng-template>
+                          </div>
+                        </ng-container>
+                      </td>
                     </ng-container>
                   </tr>
 
@@ -191,7 +201,7 @@
                             <img src="assets/svgs/diagnosis.svg" alt="" width="44px" />
                             <h6 class="mb-0 ml-2">
                               Assessment
-                              <button class="blue-btn mr-1" type="button" (click)="$event.stopPropagation();addAssessment('newborn', 7)">Add</button>
+                              <button class="blue-btn mr-1" type="button" (click)="$event.stopPropagation();addAssessment('newborn', 10)">Add</button>
                             </h6>
                           </div>
                         </mat-panel-title>
@@ -214,7 +224,7 @@
                             <img src="assets/svgs/note.svg" alt="" width="44px" />
                             <h6 class="mb-0 ml-2">
                               Plan
-                              <button class="blue-btn mr-1" type="button" (click)="$event.stopPropagation();prescribePlan('newborn', 8)">Add</button>
+                              <button class="blue-btn mr-1" type="button" (click)="$event.stopPropagation();prescribePlan('newborn', 11)">Add</button>
                             </h6>
                           </div>
                         </mat-panel-title>

--- a/src/app/dashboard/stage3/stage3.component.ts
+++ b/src/app/dashboard/stage3/stage3.component.ts
@@ -86,13 +86,16 @@ export class Stage3Component implements OnInit {
   ];
 
   newbornParams: S3Param[] = [
+    { name: 'Respiratory Rate',      conceptName: 'Respiratory Rate',      values: new Array(NUM_COLS).fill(null) },
+    { name: 'SPO2',                  conceptName: 'SPO2',                  values: new Array(NUM_COLS).fill(null) },
     { name: 'Grunting',              conceptName: 'Grunting',              values: new Array(NUM_COLS).fill(null) },
     { name: 'Chest Indrawing',       conceptName: 'Chest Indrawing',       values: new Array(NUM_COLS).fill(null) },
     { name: 'Fast Breathing',        conceptName: 'Fast Breathing',        values: new Array(NUM_COLS).fill(null) },
-    { name: 'Feet Temperature',      conceptName: 'Feet Temperature',      values: new Array(NUM_COLS).fill(null) },
+    { name: 'Feet (warm)',           conceptName: 'Feet Warm',             values: new Array(NUM_COLS).fill(null) },
     { name: 'Skin Color',            conceptName: 'Skin Color',            values: new Array(NUM_COLS).fill(null) },
     { name: 'Umbilical Cord Oozing', conceptName: 'Umbilical Cord Oozing', values: new Array(NUM_COLS).fill(null) },
     { name: 'Sucking / Feeding',     conceptName: 'Sucking Feeding',       values: new Array(NUM_COLS).fill(null) },
+    { name: 'Complications',         conceptName: 'Complication',          values: new Array(NUM_COLS).fill(null) },
     { name: 'Assessment (Newborn)',  conceptName: 'Assessment Newborn',    isTextarea: true, values: new Array(NUM_COLS).fill(null).map(() => []) },
     { name: 'Plan (Newborn)',        conceptName: 'Plan Newborn',          isTextarea: true, values: new Array(NUM_COLS).fill(null).map(() => []) },
   ];
@@ -119,10 +122,7 @@ export class Stage3Component implements OnInit {
   get user()   { return getFromStorage('user'); }
 
   getInitials(name: string): string {
-    if (!name) return '';
-    const parts = name.trim().split(' ');
-    if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
-    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+    return name ? name.trim() : '';
   }
 
   getVisit(uuid: string) {
@@ -493,6 +493,8 @@ export class Stage3Component implements OnInit {
           canEdit: this.userId === ob.creator?.uuid,
           initial: this.getInitials(ob.creator?.person?.display)
         }];
+      } else if (p.name === 'Complications') {
+        p.values[colIndex] = { value: this.formatComplication(ob.value), uuid: ob.uuid };
       } else {
         p.values[colIndex] = { value: ob.value, uuid: ob.uuid };
       }
@@ -529,14 +531,20 @@ export class Stage3Component implements OnInit {
     }
 
     if (section === 'newborn') {
-      if (param.name === 'Grunting') {
+      if (param.name === 'Respiratory Rate') {
+        aliases.push('RESPIRATORY_RATE_NEWBORN', 'Respiratory Rate Newborn', 'Respiratory rate', 'RESPIRATORY RATE');
+      } else if (param.name === 'SPO2') {
+        aliases.push('SPO2_NEWBORN', 'SpO2', 'Oxygen Saturation', 'SPO2 Newborn');
+      } else if (param.name === 'Complications') {
+        aliases.push('COMPLICATION_NEWBORN', 'Complication Newborn', 'Complication', 'Complications Newborn');
+      } else if (param.name === 'Grunting') {
         aliases.push('GRUNTING_NEWBORN');
       } else if (param.name === 'Chest Indrawing') {
         aliases.push('CHEST_INDRAWING_NEWBORN');
       } else if (param.name === 'Fast Breathing') {
         aliases.push('FAST_BREATHING_NEWBORN');
-      } else if (param.name === 'Feet Temperature') {
-        aliases.push('FEET_WARM_NEWBORN', 'Feet Warm Newborn');
+      } else if (param.name === 'Feet (warm)') {
+        aliases.push('FEET_WARM_NEWBORN', 'Feet Warm Newborn', 'Feet Warm', 'Feet Temperature');
       } else if (param.name === 'Skin Color') {
         aliases.push('SKIN_COLOR_NEWBORN');
       } else if (param.name === 'Umbilical Cord Oozing') {
@@ -560,7 +568,10 @@ export class Stage3Component implements OnInit {
     const obsConceptUuid = this.normalizeConcept(ob?.concept?.uuid);
     const aliases = this.getParamAliases(section, param);
 
-    if (aliases.includes(obsDisplay)) {
+    const normalizedAliases = aliases
+      .filter(a => a)
+      .map(a => this.normalizeConcept(a));
+    if (normalizedAliases.includes(obsDisplay)) {
       return true;
     }
 
@@ -655,11 +666,11 @@ export class Stage3Component implements OnInit {
   }
 
   get newbornAssessmentHistory(): any[] {
-    return this.getTextareaHistory(this.newbornParams[7]);
+    return this.getTextareaHistory(this.newbornParams[10]);
   }
 
   get newbornPlanHistory(): any[] {
-    return this.getTextareaHistory(this.newbornParams[8]);
+    return this.getTextareaHistory(this.newbornParams[11]);
   }
 
   private findObsLocation(param: S3Param, obsUuid: string): { colIdx: number; itemIdx: number } {
@@ -863,6 +874,13 @@ export class Stage3Component implements OnInit {
     this.router.navigate(['/dashboard']);
   }
 
+  getBpPart(value: any, part: 'systolic' | 'diastolic'): string {
+    const str = value == null ? '' : String(value);
+    if (!str) return '';
+    const [s = '', d = ''] = str.split('/');
+    return part === 'systolic' ? s.trim() : d.trim();
+  }
+
   formatColTime(time: string | null): string {
     if (!time) {
       return '';
@@ -871,7 +889,15 @@ export class Stage3Component implements OnInit {
     if (!adDate) {
       return '';
     }
-    const datePart = this.formatDateByClient(adDate);
+    let datePart: string;
+    if (this.isNepalClient) {
+      const bsDate = this.nepaliDateService.gregorianToBs(adDate);
+      datePart = bsDate
+        ? `${bsDate.year} ${this.nepaliDateService.monthNames[bsDate.month - 1]} ${String(bsDate.day).padStart(2, '0')}`
+        : moment(adDate).format('YYYY/MM/DD');
+    } else {
+      datePart = moment(adDate).format('YYYY/MM/DD');
+    }
     const timePart = moment(adDate).format('HH:mm');
     return `${datePart} ${timePart}`.trim();
   }

--- a/src/app/epartogram/epartogram.component.ts
+++ b/src/app/epartogram/epartogram.component.ts
@@ -393,11 +393,13 @@ export class EpartogramComponent implements OnInit {
     }
 
     if (!this.isNepalClient) {
-      return moment(adDate).format('DD/MM/YYYY');
+      return moment(adDate).format('YYYY/MM/DD');
     }
 
     const bsDate = this.nepaliDateService.gregorianToBs(adDate);
-    return bsDate ? this.nepaliDateService.formatBsDate(bsDate) : moment(adDate).format('DD/MM/YYYY');
+    return bsDate
+      ? `${bsDate.year} ${this.nepaliDateService.monthNames[bsDate.month - 1]} ${String(bsDate.day).padStart(2, '0')}`
+      : moment(adDate).format('YYYY/MM/DD');
   }
 
   private parseIncomingDate(dateValue: any): Date | null {
@@ -429,7 +431,7 @@ export class EpartogramComponent implements OnInit {
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
-    this.login(id);
+    if (id) { this.getVisit(id); }
     for (let x = 0; x < this.parameters.length; x++) {
       if (x == 20 || x == 22 || x == 23 || x == 26 || x == 27 || x == 28) {
         this.parameters[x]['stage1values'] = Array(this.parameters[x].stage1Count).fill([]);
@@ -468,6 +470,14 @@ export class EpartogramComponent implements OnInit {
         this.readPatientAttributes();
         this.readStageData();
         this.readStage3Data();
+        setTimeout(() => {
+          this.ele = document.getElementsByClassName('table-responsive')[0];
+          if (this.ele) {
+            this.ele.scrollTop = 0;
+            this.ele.scrollLeft = 0;
+            this.ele.addEventListener('mousedown', this.mouseDownHandler.bind(this));
+          }
+        }, 1000);
       }
     });
   }
@@ -1083,9 +1093,7 @@ export class EpartogramComponent implements OnInit {
   }
 
   getInitials(name: string) {
-    const fullName = name.split(' ');
-    const initials = fullName.shift().charAt(0) + fullName.pop().charAt(0);
-    return initials.toUpperCase();
+    return name ? name.trim() : '';
   }
 
   checkIfFutureEncounterExists(futureStartIndex) {

--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,12 @@
         if (manifest) manifest.setAttribute('href', 'manifest.nepal.webmanifest?v=20260507');
         var apple = document.querySelector('link[rel="apple-touch-icon"]');
         if (apple) apple.setAttribute('href', '/assets/icons/nepal/icon-192x192-20260507.png');
+        var favicon = document.querySelector('link[rel="icon"]');
+        if (favicon) {
+          favicon.setAttribute('type', 'image/png');
+          favicon.setAttribute('href', '/assets/nepal/jhpiego-removebg-preview.png');
+        }
+        document.title = 'NEzazi';
       } catch (e) { /* no-op */ }
     })();
   </script>


### PR DESCRIPTION
- Show YYYY/MM/DD across stage3, partogram, epartogram, and dashboard
  (BS rendered as "YYYY MonthName DD" for Nepal clients)
- stage3: normalize aliases when matching obs concepts so Systolic/Diastolic
  BP, Respiratory Rate, Blood Loss, etc. populate correctly
- stage3: render BP as labeled "Systolic: x / Diastolic: y" lines
- stage3: add Respiratory Rate, SPO2, Feet (warm), Complications to the
  newborn delivery outcome report; shift assessment/plan indexes to 10/11
- stage3/partogram/epartogram: show full creator name instead of initials
- epartogram: drop loginExternal() call so /epartogram/:id is publicly
  accessible (same model as /dashboard/stage3/:id), avoiding the basic-auth
  browser prompt on nezazi
