### PR TITLE
feat: add AI-assisted doctor's note sections to visit summary v2

### DIFF
--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
@@ -11,18 +11,79 @@
   </div>
   <div class="vs2-divider"></div>
 
-  <div class="vs2-form-row">
-    <span class="vs2-field-label">Connect with patient</span>
-    <button class="vs2-link-pill">
-      <img src="assets/svgs/phone-green.svg" alt="" /> Click here to connect with the patient
-    </button>
+  <div class="vs2-ayu-card" [class.vs2-ayu-open]="ayuQuestionsExpanded">
+    <div class="vs2-ayu-banner" (click)="ayuQuestionsExpanded = !ayuQuestionsExpanded">
+      <img class="vs2-ayu-icon" src="assets/svgs/ayu-new.svg" alt="" />
+      <div class="vs2-ayu-text">
+        <span class="vs2-ayu-title">Ayu Suggested Questions</span>
+        <span class="vs2-ayu-subtitle">Based on current symptoms and missing information</span>
+      </div>
+      <mat-icon class="vs2-ayu-chevron">{{ ayuQuestionsExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+    </div>
+
+    <div class="vs2-ayu-body" *ngIf="ayuQuestionsExpanded">
+      <div class="vs2-ayu-hint">
+        💡 <b>Ayu AI:</b> These questions help fill diagnostic gaps. Answer what you know—skip the rest.
+      </div>
+
+      <div class="vs2-ayu-question" *ngFor="let q of ayuSuggestedQuestions; let i = index">
+        <div class="vs2-ayu-q-top">
+          <span class="vs2-ayu-tag">{{ q.category }}</span>
+          <span class="vs2-ayu-q-actions">
+            <ng-container *ngIf="!q.answer && !q.editing">
+              <button class="vs2-ayu-yes" (click)="answerAyuQuestion(q, 'Yes')">Yes</button>
+              <button class="vs2-ayu-no" (click)="answerAyuQuestion(q, 'No')">No</button>
+              <button class="vs2-ayu-add" (click)="editAyuQuestion(q)">Add Answer <mat-icon>chevron_right</mat-icon></button>
+            </ng-container>
+            <mat-icon class="vs2-ayu-edit" *ngIf="q.answer || q.editing" (click)="editAyuQuestion(q)">edit_note</mat-icon>
+          </span>
+        </div>
+        <p class="vs2-ayu-q-text">{{ q.question }}</p>
+        <input class="vs2-input vs2-ayu-answer-input" *ngIf="q.editing" [(ngModel)]="q.answer"
+          [ngModelOptions]="{ standalone: true }" placeholder="Type your answer"
+          (blur)="q.editing = false" (keyup.enter)="q.editing = false" />
+        <span class="vs2-ayu-answer" *ngIf="q.answer && !q.editing">{{ q.answer }}</span>
+      </div>
+
+      <h4 class="vs2-ayu-refine-title">Refine AI Suggestions(optional)</h4>
+      <p class="vs2-ayu-refine-sub">Add clinical observations to improve diagnostic accuracy</p>
+      <textarea class="vs2-textarea vs2-ayu-refine" rows="2" placeholder="Add additional observations"
+        [(ngModel)]="ayuRefineText" [ngModelOptions]="{ standalone: true }"></textarea>
+
+      <div class="vs2-ayu-footer">
+        <button class="vs2-btn-primary" (click)="saveAyuQuestions()">Save</button>
+      </div>
+    </div>
   </div>
-  <div class="vs2-form-row">
-    <span class="vs2-field-label">Have you spoken with the patient directly?</span>
-    <label class="vs2-radio"><input type="radio" name="spoken" [value]="true" [(ngModel)]="spokenToPatient" /> Yes</label>
-    <label class="vs2-radio"><input type="radio" name="spoken" [value]="false" [(ngModel)]="spokenToPatient" /> No</label>
-  </div>
-  <button class="vs2-btn-primary">Save</button>
+
+  <ul class="vs2-bullet-list vs2-interaction-list">
+    <li>
+      <div class="vs2-form-row">
+        <span class="vs2-field-label">Connect with patient</span>
+        <span class="vs2-connect-actions">
+          <a class="vs2-icon-circle" [class.vs2-icon-circle-disabled]="!patientPhoneNo"
+            [attr.href]="patientPhoneNo ? 'tel:' + patientPhoneNo : null">
+            <img src="assets/svgs/phone-black.svg" alt="Call patient" />
+          </a>
+          <a class="vs2-icon-circle" [class.vs2-icon-circle-disabled]="!patientPhoneNo"
+            [attr.href]="whatsAppLink" target="_blank" rel="noopener">
+            <img src="assets/svgs/whatsapp-black.svg" alt="WhatsApp patient" />
+          </a>
+          <span class="vs2-connect-hint">
+            {{ patientPhoneNo ? 'Click here to connect with the patient' : 'Phone number is not available' }}
+          </span>
+        </span>
+      </div>
+    </li>
+    <li>
+      <div class="vs2-form-row">
+        <span class="vs2-field-label">Have you spoken with the patient directly?</span>
+        <label class="vs2-radio vs2-radio-green"><input type="radio" name="spoken" [value]="true" [(ngModel)]="spokenToPatient" /> Yes</label>
+        <label class="vs2-radio vs2-radio-green"><input type="radio" name="spoken" [value]="false" [(ngModel)]="spokenToPatient" /> No</label>
+      </div>
+    </li>
+  </ul>
+  <button class="vs2-btn-soft">Save</button>
 </section>
 
 <section id="section-dn-diagnosis" class="vs2-section-card">
@@ -33,42 +94,142 @@
   </div>
   <div class="vs2-divider"></div>
 
-  <h4 class="vs2-subhead vs2-subhead-purple">Add Diagnosis</h4>
-  <div class="vs2-form-row">
-    <span class="vs2-field-label">Do you have enough information to diagnose?</span>
-    <label class="vs2-radio"><input type="radio" name="enoughInfo" [value]="true" [(ngModel)]="hasEnoughInfo" /> Yes</label>
-    <label class="vs2-radio"><input type="radio" name="enoughInfo" [value]="false" [(ngModel)]="hasEnoughInfo" /> No</label>
+  <div class="vs2-ayu-card vs2-summary-card" *ngIf="aiDiagnosisState === 'ready' && aiClinicalSummary">
+    <div class="vs2-ayu-banner" (click)="aiSummaryExpanded = !aiSummaryExpanded">
+      <img class="vs2-ayu-icon" src="assets/svgs/ayu-new.svg" alt="" />
+      <div class="vs2-ayu-text">
+        <span class="vs2-ayu-title">Ai Clinical Summary</span>
+      </div>
+      <mat-icon class="vs2-ayu-chevron">{{ aiSummaryExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+    </div>
+    <p class="vs2-summary-text" *ngIf="aiSummaryExpanded">{{ aiClinicalSummary }}</p>
   </div>
-  <div class="vs2-form-row">
-    <span class="vs2-field-label">Select diagnosis</span>
-    <ng-select
-      class="vs2-ng-select"
-      [items]="diagnosisResults"
-      [(ngModel)]="selectedDiagnosis"
-      bindLabel="name"
-      [searchable]="true"
-      [clearable]="true"
-      [addTag]="false"
-      [minTermLength]="3"
-      typeToSearchText="Type at least 3 characters"
-      (search)="onDiagnosisSearch($event)"
-      placeholder="Search diagnosis">
-    </ng-select>
+
+  <h4 class="vs2-ai-dx-title">
+    <img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Diagnosis
+  </h4>
+
+  <div class="vs2-ai-panel" *ngIf="aiDiagnosisState === 'loading'">
+    <div class="vs2-ai-loading-head">
+      <mat-spinner diameter="20"></mat-spinner>
+      <div>
+        <span class="vs2-ai-loading-title">Generating AI Diagnosis..</span>
+        <span class="vs2-ai-loading-sub">This usually takes a few seconds</span>
+      </div>
+    </div>
+    <div class="vs2-skeleton-grid">
+      <div class="vs2-skeleton-chip" *ngFor="let s of [1,2,3,4,5]">
+        <span class="vs2-skeleton-dot"></span>
+        <span class="vs2-skeleton-lines"><i></i><i></i></span>
+      </div>
+    </div>
   </div>
-  <div class="vs2-form-row">
-    <span class="vs2-field-label">Diagnosis type</span>
-    <label class="vs2-radio"><input type="radio" name="dxType" value="Primary" [(ngModel)]="newDiagnosisType" /> Primary</label>
-    <label class="vs2-radio"><input type="radio" name="dxType" value="Secondary" [(ngModel)]="newDiagnosisType" /> Secondary</label>
+
+  <div class="vs2-ai-panel" *ngIf="aiDiagnosisState === 'error'">
+    <div class="vs2-ai-error">
+      <mat-icon class="vs2-ai-error-icon">error</mat-icon>
+      <div>
+        <span class="vs2-ai-error-title">We couldn't generate AI Diagnosis suggestions.</span>
+        <span class="vs2-ai-error-sub">There was a temporary issue on our end.</span>
+      </div>
+    </div>
+    <div class="vs2-ai-error-actions">
+      <button class="vs2-btn-outline" (click)="addDiagnosisManually()">Add Diagnosis Manually</button>
+      <button class="vs2-btn-primary" (click)="retryAiDiagnosis()">Try again</button>
+    </div>
   </div>
-  <div class="vs2-form-row">
-    <span class="vs2-field-label">Select</span>
-    <label class="vs2-radio"><input type="radio" name="dxStatus" value="Provisional" [(ngModel)]="newDiagnosisStatus" /> Provisional</label>
-    <label class="vs2-radio"><input type="radio" name="dxStatus" value="Confirmed" [(ngModel)]="newDiagnosisStatus" /> Confirmed</label>
+
+  <ng-container *ngIf="aiDiagnosisState === 'ready'">
+    <div class="vs2-ai-disclaimer">
+      <b>Disclaimer:</b> This AI-generated suggestion is intended to support not replace your clinical judgment and may
+      not account for all relevant factors. Please use your own judgement before acting.
+    </div>
+
+    <div class="vs2-dx-chip-row">
+      <span class="vs2-dx-chip" *ngFor="let s of aiSuggestions"
+        [ngClass]="'vs2-dx-' + s.likelihood.toLowerCase()" [class.vs2-dx-selected]="isDiagnosisSelected(s.name)"
+        (click)="toggleAiSuggestion(s)">
+        <mat-icon class="vs2-dx-check" *ngIf="isDiagnosisSelected(s.name)">check</mat-icon>
+        <span class="vs2-dx-dot" *ngIf="!isDiagnosisSelected(s.name)"></span>
+        <span class="vs2-dx-name">{{ s.name }}</span>
+        <span class="vs2-dx-badge">{{ s.likelihood }} Likely</span>
+        <mat-icon class="vs2-dx-info" (click)="toggleWhy(s, $event)">info_outline</mat-icon>
+      </span>
+    </div>
+
+    <div class="vs2-dx-why" *ngIf="whySuggestion">
+      <h5>Why {{ whySuggestion.name }}?</h5>
+      <ul class="vs2-bullet-list">
+        <li *ngFor="let r of whySuggestion.reasons">{{ r }}</li>
+      </ul>
+    </div>
+  </ng-container>
+
+  <ng-select
+    class="vs2-ng-select vs2-dx-search"
+    [items]="diagnosisResults"
+    [(ngModel)]="selectedDiagnosis"
+    bindLabel="name"
+    [searchable]="true"
+    [clearable]="true"
+    [addTag]="false"
+    [minTermLength]="3"
+    typeToSearchText="Type at least 3 characters"
+    (search)="onDiagnosisSearch($event)"
+    (change)="onDiagnosisPicked($event)"
+    placeholder="Type to search diagnosis">
+  </ng-select>
+
+  <div class="vs2-dx-quick-row">
+    <button class="vs2-dx-quick" *ngFor="let q of quickDiagnoses" [class.vs2-dx-quick-on]="isDiagnosisSelected(q)"
+      (click)="toggleQuickDiagnosis(q)">
+      <mat-icon>{{ isDiagnosisSelected(q) ? 'check' : 'add' }}</mat-icon> {{ q }}
+    </button>
   </div>
-  <div class="vs2-btn-row">
-    <button class="vs2-btn-cancel" (click)="cancelDiagnosis()">Cancel</button>
-    <button class="vs2-btn-add" (click)="addDiagnosis()">Add</button>
+
+  <div class="vs2-improve" *ngIf="aiDiagnosisState === 'ready'">
+    <div class="vs2-improve-head" (click)="improveExpanded = !improveExpanded">
+      <img src="assets/svgs/ayu-new.svg" alt="" />
+      <span class="vs2-improve-title">Improve Ai Suggestions <em>(optional)</em></span>
+      <mat-icon>{{ improveExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+    </div>
+    <ng-container *ngIf="improveExpanded">
+      <p class="vs2-improve-sub">Add more clinical context only if Ai suggestions are insufficient.</p>
+      <textarea class="vs2-textarea vs2-improve-text" rows="2" [(ngModel)]="improveContextText"
+        [ngModelOptions]="{ standalone: true }"
+        placeholder="Describe anything clinically important..&#10;e.g. Patient is pregnant - Recent travel history"></textarea>
+      <div class="vs2-dx-quick-row">
+        <button class="vs2-dx-quick" *ngFor="let c of contextChips" [class.vs2-dx-quick-on]="isContextChipOn(c)"
+          (click)="toggleContextChip(c)">
+          <mat-icon>{{ isContextChipOn(c) ? 'check' : 'add' }}</mat-icon> {{ c }}
+        </button>
+      </div>
+      <button class="vs2-btn-block" (click)="updateAiSuggestions()">Update AI Suggestions</button>
+    </ng-container>
   </div>
+
+  <ng-container *ngIf="selectedDiagnoses.length">
+    <h4 class="vs2-selected-title">Selected Diagnosis <span class="vs2-count-badge">{{ selectedDiagnoses.length }}</span></h4>
+
+    <div class="vs2-dx-row" *ngFor="let dx of selectedDiagnoses; let i = index">
+      <mat-icon class="vs2-dx-row-check">check</mat-icon>
+      <span class="vs2-dx-row-name">{{ dx.name }}</span>
+      <span class="vs2-dx-source" [class.vs2-dx-source-ai]="dx.source === 'ai'">
+        {{ dx.source === 'ai' ? 'AI Suggested' : 'Added manually' }}
+      </span>
+      <span class="vs2-segmented">
+        <button *ngFor="let t of diagnosisTypes" [class.vs2-seg-on]="dx.type === t" [ngClass]="'vs2-seg-type'"
+          (click)="dx.type = t">{{ t }}</button>
+      </span>
+      <span class="vs2-segmented">
+        <button *ngFor="let st of diagnosisStatuses" [class.vs2-seg-on]="dx.status === st" [ngClass]="'vs2-seg-status'"
+          (click)="dx.status = st">{{ st }}</button>
+      </span>
+      <mat-icon class="vs2-delete-icon" (click)="removeSelectedDiagnosis(i)">delete_outline</mat-icon>
+    </div>
+
+    <button class="vs2-btn-block" (click)="submitSelectedDiagnoses()">Add Diagnosis</button>
+  </ng-container>
 
   <ng-container *ngIf="addedDiagnoses.length">
     <h4 class="vs2-subhead vs2-subhead-purple vs2-subhead-strong">Added Diagnosis</h4>
@@ -119,77 +280,140 @@
   </div>
   <div class="vs2-divider"></div>
 
-  <h4 class="vs2-subhead vs2-subhead-purple">Add Medication</h4>
-  <div class="vs2-med-grid">
-    <div class="vs2-field">
-      <span class="vs2-field-label">Drug name</span>
-      <ng-select
-        class="vs2-ng-select vs2-ng-select-grid"
-        [items]="drugOptions"
-        [(ngModel)]="newMedicine.drug"
-        [addTag]="true"
-        [searchable]="true"
-        [clearable]="true"
-        placeholder="Select or type">
-      </ng-select>
+  <h4 class="vs2-ai-dx-title">
+    <img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Medication
+  </h4>
+
+  <div class="vs2-ai-panel vs2-ai-empty" *ngIf="medicationPanelState === 'no-diagnosis'">
+    <span class="vs2-ai-empty-icon"><img src="assets/svgs/diagnosis.svg" alt="" /></span>
+    <span class="vs2-ai-empty-title">No Diagnosis Provided</span>
+    <span class="vs2-ai-empty-sub">AI-assisted medicines suggestions are based on the diagnosis.<br />Please add the
+      required diagnostic details to continue.</span>
+  </div>
+
+  <div class="vs2-ai-panel" *ngIf="medicationPanelState === 'loading'">
+    <div class="vs2-ai-loading-head">
+      <mat-spinner diameter="20"></mat-spinner>
+      <div>
+        <span class="vs2-ai-loading-title">Generating AI Medication..</span>
+        <span class="vs2-ai-loading-sub">This usually takes a few seconds</span>
+      </div>
     </div>
-    <div class="vs2-field">
-      <span class="vs2-field-label">Dosage</span>
-      <ng-select
-        class="vs2-ng-select vs2-ng-select-grid"
-        [items]="doseOptions"
-        [(ngModel)]="newMedicine.dose"
-        [addTag]="true"
-        [searchable]="true"
-        [clearable]="true"
-        placeholder="Enter">
-      </ng-select>
-    </div>
-    <div class="vs2-field">
-      <span class="vs2-field-label">Frequency</span>
-      <ng-select
-        class="vs2-ng-select vs2-ng-select-grid"
-        [items]="frequencyOptions"
-        [(ngModel)]="newMedicine.frequency"
-        [addTag]="true"
-        [searchable]="true"
-        [clearable]="true"
-        placeholder="Select or type">
-      </ng-select>
-    </div>
-    <div class="vs2-field">
-      <span class="vs2-field-label">Duration (no.)</span>
-      <input class="vs2-input" placeholder="Enter" [(ngModel)]="newMedicine.durationNo" />
-    </div>
-    <div class="vs2-field">
-      <span class="vs2-field-label">Duration (units)</span>
-      <ng-select
-        class="vs2-ng-select vs2-ng-select-grid"
-        [items]="durationUnitOptions"
-        [(ngModel)]="newMedicine.durationUnit"
-        [addTag]="true"
-        [searchable]="true"
-        [clearable]="true"
-        placeholder="Select">
-      </ng-select>
-    </div>
-    <div class="vs2-field">
-      <span class="vs2-field-label">Instruction (Remarks)</span>
-      <ng-select
-        class="vs2-ng-select vs2-ng-select-grid"
-        [items]="instructionOptions"
-        [(ngModel)]="newMedicine.instructRemark"
-        [addTag]="true"
-        [searchable]="true"
-        [clearable]="true"
-        placeholder="Select or type">
-      </ng-select>
+    <div class="vs2-skeleton-grid">
+      <div class="vs2-skeleton-chip" *ngFor="let s of [1,2,3,4,5]">
+        <span class="vs2-skeleton-dot"></span>
+        <span class="vs2-skeleton-lines"><i></i><i></i></span>
+      </div>
     </div>
   </div>
-  <div class="vs2-btn-row">
-    <button class="vs2-btn-cancel" (click)="cancelMedicine()">Cancel</button>
-    <button class="vs2-btn-add" (click)="addMedicine()">Add</button>
+
+  <div class="vs2-ai-panel" *ngIf="medicationPanelState === 'error'">
+    <div class="vs2-ai-error">
+      <mat-icon class="vs2-ai-error-icon">error</mat-icon>
+      <div>
+        <span class="vs2-ai-error-title">We couldn't generate AI medication suggestions.</span>
+        <span class="vs2-ai-error-sub">There was a temporary issue on our end.</span>
+      </div>
+    </div>
+    <div class="vs2-ai-error-actions">
+      <button class="vs2-btn-outline" (click)="addMedicationManually()">Add Medication Manually</button>
+      <button class="vs2-btn-primary" (click)="retryAiMedication()">Try again</button>
+    </div>
   </div>
+
+  <ng-container *ngIf="medicationPanelState === 'ready'">
+    <div class="vs2-ai-disclaimer">
+      <b>Disclaimer:</b> This AI-generated suggestion is intended to support not replace your clinical judgment and may
+      not account for all relevant factors. Please use your own judgement before acting.
+    </div>
+
+    <div class="vs2-dx-chip-row">
+      <span class="vs2-dx-chip" *ngFor="let s of aiMedicationSuggestions"
+        [ngClass]="'vs2-dx-' + s.likelihood.toLowerCase()" [class.vs2-dx-selected]="isMedicineSelected(s.name)"
+        (click)="toggleAiMedication(s)">
+        <mat-icon class="vs2-dx-check" *ngIf="isMedicineSelected(s.name)">check</mat-icon>
+        <span class="vs2-dx-dot" *ngIf="!isMedicineSelected(s.name)"></span>
+        <span class="vs2-dx-name">{{ isMedicineSelected(s.name) ? s.name : s.label }}</span>
+        <span class="vs2-dx-badge">{{ s.likelihood }} Likely</span>
+        <mat-icon class="vs2-dx-info" (click)="toggleMedicationWhy(s, $event)">info_outline</mat-icon>
+      </span>
+    </div>
+
+    <div class="vs2-dx-why" *ngIf="whyMedication">
+      <h5>Why {{ whyMedication.name }} ?</h5>
+      <ul class="vs2-bullet-list">
+        <li *ngFor="let r of whyMedication.reasons">{{ r }}</li>
+      </ul>
+    </div>
+  </ng-container>
+
+  <ng-select
+    class="vs2-ng-select vs2-dx-search"
+    [items]="drugOptions"
+    [(ngModel)]="searchedDrug"
+    [addTag]="true"
+    [searchable]="true"
+    [clearable]="true"
+    (change)="onMedicinePicked($event)"
+    placeholder="Type to search medication">
+  </ng-select>
+
+  <div class="vs2-dx-quick-row">
+    <button class="vs2-dx-quick" *ngFor="let q of quickMedicines" [class.vs2-dx-quick-on]="isMedicineSelected(q)"
+      (click)="toggleQuickMedicine(q)">
+      <mat-icon>{{ isMedicineSelected(q) ? 'check' : 'add' }}</mat-icon> {{ q }}
+    </button>
+  </div>
+
+  <ng-container *ngIf="selectedMedicines.length">
+    <h4 class="vs2-selected-title">Selected Medication <span class="vs2-count-badge">{{ selectedMedicines.length }}</span></h4>
+
+    <div class="vs2-med-card" *ngFor="let m of selectedMedicines; let i = index">
+      <div class="vs2-med-card-head">
+        <mat-icon class="vs2-dx-row-check">check</mat-icon>
+        <span class="vs2-dx-row-name">{{ m.drug }}</span>
+        <span class="vs2-dx-source" [class.vs2-dx-source-ai]="m.source === 'ai'">
+          {{ m.source === 'ai' ? 'AI Suggested' : 'Added manually' }}
+        </span>
+        <span class="vs2-med-card-actions">
+          <ng-container *ngIf="m.editing">
+            <mat-icon class="vs2-confirm-icon" (click)="m.editing = false">check</mat-icon>
+            <mat-icon class="vs2-cancel-icon" (click)="cancelMedicineEdit(i)">close</mat-icon>
+          </ng-container>
+          <ng-container *ngIf="!m.editing">
+            <mat-icon class="vs2-edit-icon" (click)="m.editing = true">edit_note</mat-icon>
+            <mat-icon class="vs2-delete-icon" (click)="removeSelectedMedicine(i)">delete_outline</mat-icon>
+          </ng-container>
+        </span>
+      </div>
+
+      <div class="vs2-med-card-grid">
+        <span class="vs2-med-col-label">Timing</span>
+        <span class="vs2-med-col-label">Strength</span>
+        <span class="vs2-med-col-label">No.of days</span>
+        <span class="vs2-med-col-label">Remarks</span>
+
+        <ng-container *ngIf="!m.editing">
+          <span class="vs2-med-col-value">{{ m.timing || '-' }}</span>
+          <span class="vs2-med-col-value">{{ m.strength || '-' }}</span>
+          <span class="vs2-med-col-value">{{ m.days || '-' }}</span>
+          <span class="vs2-med-col-value">{{ m.remarks || '-' }}</span>
+        </ng-container>
+
+        <ng-container *ngIf="m.editing">
+          <ng-select class="vs2-ng-select vs2-ng-select-grid" [items]="timingOptions" [(ngModel)]="m.timing"
+            [addTag]="true" [clearable]="false" placeholder="Select Timing"></ng-select>
+          <ng-select class="vs2-ng-select vs2-ng-select-grid" [items]="doseOptions" [(ngModel)]="m.strength"
+            [addTag]="true" [clearable]="false" placeholder="Strength"></ng-select>
+          <ng-select class="vs2-ng-select vs2-ng-select-grid" [items]="dayOptions" [(ngModel)]="m.days"
+            [addTag]="true" [clearable]="false" placeholder="Enter day"></ng-select>
+          <input class="vs2-input" [(ngModel)]="m.remarks" placeholder="Enter Remarks" />
+        </ng-container>
+      </div>
+    </div>
+
+    <button class="vs2-btn-block" [disabled]="!canSubmitMedicines" (click)="submitSelectedMedicines()">Add Medication</button>
+  </ng-container>
 
   <ng-container *ngIf="addedMedicines.length">
     <h4 class="vs2-subhead vs2-subhead-purple vs2-subhead-strong">Added Medication</h4>
@@ -238,24 +462,59 @@
   </div>
   <div class="vs2-divider"></div>
 
-  <div class="vs2-list-item" *ngFor="let a of advices; let i = index">
-    <span class="vs2-detail-label">{{ a.value }}</span>
-    <mat-icon class="vs2-delete-icon" (click)="deleteAdvice(i, a.uuid)">delete_outline</mat-icon>
+  <h4 class="vs2-selected-title vs2-bundle-title">Advice Bundles</h4>
+
+  <div class="vs2-bundle-row">
+    <div class="vs2-bundle" *ngFor="let b of adviceBundles">
+      <button class="vs2-bundle-chip" [class.vs2-bundle-chip-open]="openBundle === b" (click)="toggleBundle(b)">
+        {{ b.name }} <mat-icon>{{ openBundle === b ? 'expand_less' : 'expand_more' }}</mat-icon>
+      </button>
+
+      <div class="vs2-bundle-panel" *ngIf="openBundle === b">
+        <div class="vs2-bundle-panel-head">
+          <span>{{ b.name }}</span>
+          <mat-icon (click)="openBundle = null">close</mat-icon>
+        </div>
+        <button class="vs2-bundle-item" *ngFor="let item of b.items" [class.vs2-bundle-item-on]="isAdviceSelected(item)"
+          (click)="toggleAdvice(item)">
+          <mat-icon>{{ isAdviceSelected(item) ? 'check' : 'add' }}</mat-icon> {{ item }}
+        </button>
+      </div>
+    </div>
   </div>
 
-  <span class="vs2-field-label">Advice<span class="vs2-req">*</span></span>
   <ng-select
-    class="vs2-ng-select vs2-ng-select-grid"
+    class="vs2-ng-select vs2-dx-search"
     [items]="adviceOptions"
     [(ngModel)]="newAdviceText"
     [addTag]="true"
     [searchable]="true"
     [clearable]="true"
-    placeholder="Add advice to patient">
+    (change)="onAdvicePicked($event)"
+    placeholder="Type to search advice or type custom advice">
   </ng-select>
+
+  <div class="vs2-dx-quick-row">
+    <button class="vs2-dx-quick" *ngFor="let q of quickAdvices" [class.vs2-dx-quick-on]="isAdviceSelected(q)"
+      (click)="toggleAdvice(q)">
+      <mat-icon>{{ isAdviceSelected(q) ? 'check' : 'add' }}</mat-icon> {{ q }}
+    </button>
+  </div>
+
+  <ul class="vs2-bullet-list vs2-advice-list">
+    <li *ngFor="let a of selectedAdvices; let i = index">
+      {{ a }}
+      <mat-icon class="vs2-delete-icon" (click)="removeSelectedAdvice(i)">delete_outline</mat-icon>
+    </li>
+    <li *ngFor="let a of advices; let i = index">
+      {{ a.value }}
+      <mat-icon class="vs2-delete-icon" (click)="deleteAdvice(i, a.uuid)">delete_outline</mat-icon>
+    </li>
+  </ul>
+
   <div class="vs2-btn-row">
-    <button class="vs2-btn-cancel" (click)="cancelAdvice()">Cancel</button>
-    <button class="vs2-btn-add" (click)="addAdvice()">Add Advice</button>
+    <button class="vs2-btn-outline" (click)="cancelAdvice()">Cancel</button>
+    <button class="vs2-btn-soft" (click)="addAdvice()">Add Advice</button>
   </div>
 </section>
 

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
@@ -13,6 +13,10 @@ import {
   DiagnosisOption, DraftAdvice, DraftDiagnosis, DraftMedication, DraftReferral,
   DraftTest, DraftTextItem, VisitSummaryV2Service
 } from '../visit-summary-v2.service';
+import {
+  AdviceBundle, AiDiagnosisState, AiDiagnosisSuggestion, AiMedicationState, AiMedicationSuggestion,
+  AyuSuggestedQuestion, SelectedDiagnosis, SelectedMedicine
+} from '../visit-summary-v2.models';
 
 @Component({
   selector: 'app-doctor-note',
@@ -23,10 +27,40 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   @Input() patientUuid!: string;
   @Input() visitUuid!: string;
   @Input() visitNoteUuid!: string;
+  @Input() patientPhoneNo = '';
 
   spokenToPatient = true;
+  ayuQuestionsExpanded = false;
+  ayuSuggestedQuestions: AyuSuggestedQuestion[] = [
+    { category: 'Symptom Timing', question: 'Does the patient experience headaches more in the morning or evening?', answer: 'No' },
+    { category: 'Associated Symptoms', question: 'Is there any visual disturbance (blurred vision, seeing spots)?', answer: 'Seeing Spots', editing: true },
+    { category: 'Clinical Signs', question: 'Has the patient noticed sudden weight gain in the past week?', answer: '' }
+  ];
+  ayuRefineText = '';
 
   hasEnoughInfo = true;
+
+  aiDiagnosisState: AiDiagnosisState = 'ready';
+  aiSummaryExpanded = false;
+  improveExpanded = true;
+  improveContextText = '';
+  contextChips = ['Pregnancy', 'Travel History', 'Immunocompromised', 'Weight Loss', 'Chronic Disease'];
+  selectedContextChips: string[] = [];
+  whySuggestion: AiDiagnosisSuggestion | null = null;
+  diagnosisTypes = ['Primary', 'Secondary'];
+  diagnosisStatuses = ['Provisional', 'Confirmed', 'Under Evaluation'];
+  quickDiagnoses = ['Viral Fever', 'Hypertension', 'UTI', 'Diabetes', 'Pregnancy'];
+  selectedDiagnoses: SelectedDiagnosis[] = [];
+
+  aiClinicalSummary = 'The most likely diagnoses for this patient are Urinary Tract Infection (UTI), Viral Fever, and Anemia, given the symptoms of burning sensation during urination, prolonged fever with chills and night sweats, and signs of anemia like pale pallor and pale nails. These conditions are common in rural India and can be managed with appropriate treatment. The presence of significant vital sign abnormalities suggests the need for further evaluation.';
+  aiSuggestions: AiDiagnosisSuggestion[] = [
+    { name: 'Dengue', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
+    { name: 'Viral Fever', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
+    { name: 'URI', likelihood: 'Moderate', reasons: ['Sore throat reported', 'Nasal congestion'] },
+    { name: 'Malaria', likelihood: 'Less', reasons: ['Fever with chills', 'Endemic area'] },
+    { name: 'Typhiod', likelihood: 'Less', reasons: ['Prolonged fever', 'Abdominal discomfort'] }
+  ];
+
   selectedDiagnosis: DiagnosisOption | null = null;
   diagnosisResults: DiagnosisOption[] = [];
   private diagnosisSearch$ = new Subject<string>();
@@ -49,6 +83,21 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     'Every 30 minutes', 'Every hour', 'Every four hours', 'Every eight hours',
     'Twice daily before meals', 'Twice daily after meals'
   ];
+  aiMedicationState: AiMedicationState = 'ready';
+  whyMedication: AiMedicationSuggestion | null = null;
+  searchedDrug: string | null = null;
+  selectedMedicines: SelectedMedicine[] = [];
+  quickMedicines = ['Paracetamol', 'Lisinopril', 'Nitrofurantoin', 'Metformin', 'Prenatal vitamins'];
+  timingOptions = ['1 - 0 - 0', '0 - 1 - 0', '0 - 0 - 1', '1 - 0 - 1', '1 - 1 - 1'];
+  dayOptions = ['3', '5', '7', '10', '15', '30'];
+
+  aiMedicationSuggestions: AiMedicationSuggestion[] = [
+    { name: 'Cetirizine', label: 'Cetirizine 100mg', likelihood: 'High', reasons: ['Fast relief from allergy symptoms.', 'Non-drowsy formula', 'Suitable for daily use'] },
+    { name: 'Zylip 150mg', label: 'Zylip 150mg', likelihood: 'High', reasons: ['Matches the suggested diagnosis', 'Well tolerated at this dose'] },
+    { name: 'Azicip 500mg', label: 'Azicip 500mg', likelihood: 'Moderate', reasons: ['Covers likely bacterial cause', 'Short course option'] },
+    { name: 'Dolo 500mg', label: 'Dolo 500mg', likelihood: 'Less', reasons: ['Symptomatic fever relief only'] }
+  ];
+
   newMedicine: { drug: string | null; dose: string | null; frequency: string | null; durationNo: string; durationUnit: string | null; instructRemark: string | null } =
     { drug: null, dose: null, frequency: null, durationNo: '', durationUnit: null, instructRemark: null };
   addedMedicines: DraftMedication[] = [];
@@ -60,6 +109,39 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   newAdviceText: string | null = null;
   adviceOptions: string[] = [];
   advices: DraftAdvice[] = [];
+  selectedAdvices: string[] = [];
+  openBundle: AdviceBundle | null = null;
+  quickAdvices = ['Light Exercise', 'Drink 2-3 liters of water', 'Use Lukewarm water', 'Follow up in 7 days'];
+  adviceBundles: AdviceBundle[] = [
+    {
+      name: 'Pregnancy',
+      items: ['Daily fetal movement count', 'Take iron and calcium supplements regularly', 'Attend all scheduled ANC visits',
+        'Stay hydrated', 'Avoid heavy lifting', 'Sleep on your left side', 'Report vaginal bleeding immediately']
+    },
+    {
+      name: 'Hypertension',
+      items: ['Monitor BP twice daily', 'Reduce salt intake', 'Avoid smoking and alcohol', 'Light exercise 30 min daily',
+        'Take medication at same time daily']
+    },
+    {
+      name: 'Fever',
+      items: ['Drink 2-3 liters of fluids daily', 'Take complete bed rest for 3-5 days', 'Monitor temperature twice daily',
+        'Use lukeward water', 'Return if fever exceeds 103°F']
+    },
+    {
+      name: 'Diabetes',
+      items: ['Monitor blood glucose daily', 'Avoid high-sugar foods', 'Walk 30 minutes daily after meals',
+        'Maintain regular meal timing', 'Inspect feet daily for cuts']
+    },
+    {
+      name: 'Lifestyle',
+      items: ['Stay hydrated', 'Take adequate rest', 'Light exercise 30 min daily', 'Eat balanced diet', 'Get 7-8 hours sleep']
+    },
+    {
+      name: 'Follow-up',
+      items: ['Follow up in 5-7 days', 'Complete medication course', 'Report if symptoms worsen', 'Schedule next appointment']
+    }
+  ];
 
   newTestText: string | null = null;
   testOptions: string[] = [];
@@ -90,6 +172,26 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     private coreService: CoreService,
     private router: Router
   ) {}
+
+  get whatsAppLink(): string | null {
+    if (!this.patientPhoneNo) {
+      return null;
+    }
+    return `https://wa.me/${this.patientPhoneNo.replace(/[^\d]/g, '')}`;
+  }
+
+  answerAyuQuestion(q: AyuSuggestedQuestion, answer: string): void {
+    q.answer = answer;
+    q.editing = false;
+  }
+
+  editAyuQuestion(q: AyuSuggestedQuestion): void {
+    q.editing = true;
+  }
+
+  saveAyuQuestions(): void {
+    this.ayuSuggestedQuestions.forEach(q => { q.editing = false; });
+  }
 
   ngOnInit(): void {
     this.diagnosisSearch$.pipe(
@@ -139,6 +241,84 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.diagnosisSearch$.next(event.term);
   }
 
+  isDiagnosisSelected(name: string): boolean {
+    return this.selectedDiagnoses.some(d => d.name.toLowerCase() === name.toLowerCase());
+  }
+
+  toggleAiSuggestion(suggestion: AiDiagnosisSuggestion): void {
+    this.toggleSelectedDiagnosis(suggestion.name, 'ai');
+  }
+
+  toggleQuickDiagnosis(name: string): void {
+    this.toggleSelectedDiagnosis(name, 'manual');
+  }
+
+  private toggleSelectedDiagnosis(name: string, source: 'ai' | 'manual', code = 'NA'): void {
+    const index = this.selectedDiagnoses.findIndex(d => d.name.toLowerCase() === name.toLowerCase());
+    if (index > -1) {
+      this.selectedDiagnoses.splice(index, 1);
+      return;
+    }
+    this.selectedDiagnoses.push({ name, code, source, type: 'Primary', status: 'Provisional' });
+  }
+
+  toggleWhy(suggestion: AiDiagnosisSuggestion, event: Event): void {
+    event.stopPropagation();
+    this.whySuggestion = this.whySuggestion === suggestion ? null : suggestion;
+  }
+
+  onDiagnosisPicked(option: DiagnosisOption | null): void {
+    if (!option?.name) { return; }
+    this.toggleSelectedDiagnosis(option.name, 'manual', option.code || 'NA');
+    this.selectedDiagnosis = null;
+  }
+
+  removeSelectedDiagnosis(index: number): void {
+    this.selectedDiagnoses.splice(index, 1);
+  }
+
+  submitSelectedDiagnoses(): void {
+    if (!this.canWrite()) { return; }
+    [...this.selectedDiagnoses].forEach(dx => {
+      const payload = { name: dx.name, type: dx.type, status: dx.status, code: dx.code || 'NA' };
+      this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, payload).subscribe(res => {
+        this.addedDiagnoses.push({ ...payload, uuid: res?.uuid || '' });
+        const index = this.selectedDiagnoses.findIndex(d => d.name === dx.name);
+        if (index > -1) { this.selectedDiagnoses.splice(index, 1); }
+      });
+    });
+  }
+
+  isContextChipOn(chip: string): boolean {
+    return this.selectedContextChips.includes(chip);
+  }
+
+  toggleContextChip(chip: string): void {
+    const index = this.selectedContextChips.indexOf(chip);
+    if (index > -1) {
+      this.selectedContextChips.splice(index, 1);
+    } else {
+      this.selectedContextChips.push(chip);
+    }
+  }
+
+  updateAiSuggestions(): void {
+    this.aiDiagnosisState = 'loading';
+    this.whySuggestion = null;
+    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, 1500);
+  }
+
+  addDiagnosisManually(): void {
+    this.aiDiagnosisState = 'ready';
+    this.aiSuggestions = [];
+    this.aiClinicalSummary = '';
+  }
+
+  retryAiDiagnosis(): void {
+    this.aiDiagnosisState = 'loading';
+    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, 1500);
+  }
+
   addDiagnosis(): void {
     if (!this.selectedDiagnosis?.name || !this.canWrite()) { return; }
     const dx = {
@@ -181,6 +361,91 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.removeItem(this.addedDiagnoses, index, uuid);
   }
 
+  get medicationPanelState(): AiMedicationState {
+    const hasDiagnosis = this.selectedDiagnoses.length > 0 || this.addedDiagnoses.length > 0;
+    return !hasDiagnosis && this.aiMedicationState === 'ready' ? 'no-diagnosis' : this.aiMedicationState;
+  }
+
+  get canSubmitMedicines(): boolean {
+    return this.selectedMedicines.length > 0 &&
+      this.selectedMedicines.every(m => !!m.timing && !!m.strength && !!m.days);
+  }
+
+  isMedicineSelected(name: string): boolean {
+    return this.selectedMedicines.some(m => m.drug.toLowerCase() === name.toLowerCase());
+  }
+
+  toggleAiMedication(suggestion: AiMedicationSuggestion): void {
+    this.toggleSelectedMedicine(suggestion.name, 'ai');
+  }
+
+  toggleQuickMedicine(name: string): void {
+    this.toggleSelectedMedicine(name, 'manual');
+  }
+
+  private toggleSelectedMedicine(drug: string, source: 'ai' | 'manual'): void {
+    const index = this.selectedMedicines.findIndex(m => m.drug.toLowerCase() === drug.toLowerCase());
+    if (index > -1) {
+      this.selectedMedicines.splice(index, 1);
+      return;
+    }
+    this.selectedMedicines.push({ drug, source, timing: '', strength: '', days: '', remarks: '', editing: true });
+  }
+
+  toggleMedicationWhy(suggestion: AiMedicationSuggestion, event: Event): void {
+    event.stopPropagation();
+    this.whyMedication = this.whyMedication === suggestion ? null : suggestion;
+  }
+
+  onMedicinePicked(drug: string | null): void {
+    if (!drug) { return; }
+    this.toggleSelectedMedicine(drug, 'manual');
+    this.searchedDrug = null;
+  }
+
+  cancelMedicineEdit(index: number): void {
+    const m = this.selectedMedicines[index];
+    if (!m) { return; }
+    if (!m.timing && !m.strength && !m.days && !m.remarks) {
+      this.selectedMedicines.splice(index, 1);
+      return;
+    }
+    m.editing = false;
+  }
+
+  removeSelectedMedicine(index: number): void {
+    this.selectedMedicines.splice(index, 1);
+  }
+
+  submitSelectedMedicines(): void {
+    if (!this.canWrite() || !this.canSubmitMedicines) { return; }
+    [...this.selectedMedicines].forEach(m => {
+      const med = {
+        drug: m.drug,
+        dose: m.strength,
+        frequency: m.timing,
+        durationNo: m.days,
+        durationUnit: 'Days',
+        instructRemark: m.remarks
+      };
+      this.v2Service.saveMedication(this.patientUuid, this.visitNoteUuid, med).subscribe(res => {
+        this.addedMedicines.push({ ...med, uuid: res?.uuid || '' });
+        const index = this.selectedMedicines.findIndex(x => x.drug === m.drug);
+        if (index > -1) { this.selectedMedicines.splice(index, 1); }
+      });
+    });
+  }
+
+  addMedicationManually(): void {
+    this.aiMedicationState = 'ready';
+    this.aiMedicationSuggestions = [];
+  }
+
+  retryAiMedication(): void {
+    this.aiMedicationState = 'loading';
+    setTimeout(() => { this.aiMedicationState = 'ready'; }, 1500);
+  }
+
   addMedicine(): void {
     if (!this.canWrite()) { return; }
     const m = this.newMedicine;
@@ -220,16 +485,45 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.removeItem(this.addedMedicines, index, uuid);
   }
 
-  addAdvice(): void {
-    if (!this.newAdviceText || !this.canWrite()) { return; }
-    const value = this.newAdviceText;
-    if (this.advices.find(a => a.value === value)) {
+  toggleBundle(bundle: AdviceBundle): void {
+    this.openBundle = this.openBundle === bundle ? null : bundle;
+  }
+
+  isAdviceSelected(value: string): boolean {
+    return this.selectedAdvices.includes(value) || this.advices.some(a => a.value === value);
+  }
+
+  toggleAdvice(value: string): void {
+    if (this.advices.some(a => a.value === value)) {
       this.coreService.showToast('warning', 'Advice already added, please add another advice.', 'Already Added', 'warning-advice-toast');
       return;
     }
-    this.v2Service.saveAdvice(this.patientUuid, this.visitNoteUuid, value).subscribe(res => {
-      this.advices.push({ value, uuid: res?.uuid || '' });
-      this.newAdviceText = null;
+    const index = this.selectedAdvices.indexOf(value);
+    if (index > -1) {
+      this.selectedAdvices.splice(index, 1);
+    } else {
+      this.selectedAdvices.push(value);
+    }
+  }
+
+  onAdvicePicked(value: string | null): void {
+    if (!value) { return; }
+    this.toggleAdvice(value);
+    this.newAdviceText = null;
+  }
+
+  removeSelectedAdvice(index: number): void {
+    this.selectedAdvices.splice(index, 1);
+  }
+
+  addAdvice(): void {
+    if (!this.selectedAdvices.length || !this.canWrite()) { return; }
+    [...this.selectedAdvices].forEach(value => {
+      this.v2Service.saveAdvice(this.patientUuid, this.visitNoteUuid, value).subscribe(res => {
+        this.advices.push({ value, uuid: res?.uuid || '' });
+        const index = this.selectedAdvices.indexOf(value);
+        if (index > -1) { this.selectedAdvices.splice(index, 1); }
+      });
     });
   }
 
@@ -239,6 +533,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   cancelAdvice(): void {
     this.newAdviceText = null;
+    this.selectedAdvices = [];
+    this.openBundle = null;
   }
 
   addTest(): void {

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
@@ -2,11 +2,7 @@ import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/cor
 import { Router } from '@angular/router';
 import { Subject, of } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
-import { doctorDetails, facility, refer_prioritie } from 'src/config/constant';
-import medicines from 'src/app/core/data/medicines';
-import doses from 'src/app/core/data/dose';
-import durationUnits from 'src/app/core/data/durationUnitList';
-import instructionRemarks from 'src/app/core/data/instructionRemarks';
+import { doctorDetails } from 'src/config/constant';
 import { getCacheData } from 'src/app/utils/utility-functions';
 import { CoreService } from 'src/app/services/core/core.service';
 import {
@@ -17,6 +13,15 @@ import {
   AdviceBundle, AiDiagnosisState, AiDiagnosisSuggestion, AiMedicationState, AiMedicationSuggestion,
   AyuSuggestedQuestion, SelectedDiagnosis, SelectedMedicine
 } from '../visit-summary-v2.models';
+import {
+  ADVICE_BUNDLES, AI_SUGGESTION_DELAY_MS, CONTEXT_CHIPS, DAY_OPTIONS, DEFAULT_AI_CLINICAL_SUMMARY,
+  DEFAULT_AI_DIAGNOSIS_SUGGESTIONS, DEFAULT_AI_MEDICATION_SUGGESTIONS, DEFAULT_AYU_SUGGESTED_QUESTIONS,
+  DEFAULT_DIAGNOSIS_CODE, DEFAULT_DIAGNOSIS_STATUS, DEFAULT_DIAGNOSIS_TYPE, DEFAULT_MEDICINE_DURATION_UNIT,
+  DIAGNOSIS_SEARCH_DEBOUNCE_MS, DIAGNOSIS_SEARCH_MIN_LENGTH, DIAGNOSIS_STATUSES, DIAGNOSIS_TYPES,
+  DOSE_OPTIONS, DRUG_OPTIONS, DURATION_UNIT_OPTIONS, FACILITY_OPTIONS, FREQUENCY_OPTIONS,
+  INSTRUCTION_OPTIONS, QUICK_ADVICES, QUICK_DIAGNOSES, QUICK_MEDICINES, REFERRAL_PRIORITIES,
+  TIMING_OPTIONS
+} from './doctor-note.constants';
 
 @Component({
   selector: 'app-doctor-note',
@@ -29,13 +34,26 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   @Input() visitNoteUuid!: string;
   @Input() patientPhoneNo = '';
 
+  readonly contextChips = CONTEXT_CHIPS;
+  readonly diagnosisTypes = DIAGNOSIS_TYPES;
+  readonly diagnosisStatuses = DIAGNOSIS_STATUSES;
+  readonly quickDiagnoses = QUICK_DIAGNOSES;
+  readonly drugOptions = DRUG_OPTIONS;
+  readonly doseOptions = DOSE_OPTIONS;
+  readonly durationUnitOptions = DURATION_UNIT_OPTIONS;
+  readonly instructionOptions = INSTRUCTION_OPTIONS;
+  readonly frequencyOptions = FREQUENCY_OPTIONS;
+  readonly quickMedicines = QUICK_MEDICINES;
+  readonly timingOptions = TIMING_OPTIONS;
+  readonly dayOptions = DAY_OPTIONS;
+  readonly quickAdvices = QUICK_ADVICES;
+  readonly adviceBundles = ADVICE_BUNDLES;
+  readonly facilityOptions = FACILITY_OPTIONS;
+  readonly referralPriorities = REFERRAL_PRIORITIES;
+
   spokenToPatient = true;
   ayuQuestionsExpanded = false;
-  ayuSuggestedQuestions: AyuSuggestedQuestion[] = [
-    { category: 'Symptom Timing', question: 'Does the patient experience headaches more in the morning or evening?', answer: 'No' },
-    { category: 'Associated Symptoms', question: 'Is there any visual disturbance (blurred vision, seeing spots)?', answer: 'Seeing Spots', editing: true },
-    { category: 'Clinical Signs', question: 'Has the patient noticed sudden weight gain in the past week?', answer: '' }
-  ];
+  ayuSuggestedQuestions: AyuSuggestedQuestion[] = DEFAULT_AYU_SUGGESTED_QUESTIONS.map(q => ({ ...q }));
   ayuRefineText = '';
 
   hasEnoughInfo = true;
@@ -44,28 +62,18 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   aiSummaryExpanded = false;
   improveExpanded = true;
   improveContextText = '';
-  contextChips = ['Pregnancy', 'Travel History', 'Immunocompromised', 'Weight Loss', 'Chronic Disease'];
   selectedContextChips: string[] = [];
   whySuggestion: AiDiagnosisSuggestion | null = null;
-  diagnosisTypes = ['Primary', 'Secondary'];
-  diagnosisStatuses = ['Provisional', 'Confirmed', 'Under Evaluation'];
-  quickDiagnoses = ['Viral Fever', 'Hypertension', 'UTI', 'Diabetes', 'Pregnancy'];
   selectedDiagnoses: SelectedDiagnosis[] = [];
 
-  aiClinicalSummary = 'The most likely diagnoses for this patient are Urinary Tract Infection (UTI), Viral Fever, and Anemia, given the symptoms of burning sensation during urination, prolonged fever with chills and night sweats, and signs of anemia like pale pallor and pale nails. These conditions are common in rural India and can be managed with appropriate treatment. The presence of significant vital sign abnormalities suggests the need for further evaluation.';
-  aiSuggestions: AiDiagnosisSuggestion[] = [
-    { name: 'Dengue', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
-    { name: 'Viral Fever', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
-    { name: 'URI', likelihood: 'Moderate', reasons: ['Sore throat reported', 'Nasal congestion'] },
-    { name: 'Malaria', likelihood: 'Less', reasons: ['Fever with chills', 'Endemic area'] },
-    { name: 'Typhiod', likelihood: 'Less', reasons: ['Prolonged fever', 'Abdominal discomfort'] }
-  ];
+  aiClinicalSummary = DEFAULT_AI_CLINICAL_SUMMARY;
+  aiSuggestions: AiDiagnosisSuggestion[] = [...DEFAULT_AI_DIAGNOSIS_SUGGESTIONS];
 
   selectedDiagnosis: DiagnosisOption | null = null;
   diagnosisResults: DiagnosisOption[] = [];
   private diagnosisSearch$ = new Subject<string>();
-  newDiagnosisType = 'Primary';
-  newDiagnosisStatus = 'Provisional';
+  newDiagnosisType = DEFAULT_DIAGNOSIS_TYPE;
+  newDiagnosisStatus = DEFAULT_DIAGNOSIS_STATUS;
   addedDiagnoses: DraftDiagnosis[] = [];
   private editDiagnosisUuid = '';
   private editDiagnosisIndex = -1;
@@ -74,29 +82,12 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   newNoteText = '';
   outcomeNotes: DraftTextItem[] = [];
 
-  drugOptions: string[] = medicines.map(m => m.name);
-  doseOptions: string[] = doses.map(d => d.name);
-  durationUnitOptions: string[] = durationUnits.map(u => u.name);
-  instructionOptions: string[] = instructionRemarks.map(i => i.name);
-  frequencyOptions: string[] = [
-    'Once daily', 'Twice daily', 'Three times daily', 'Four times daily',
-    'Every 30 minutes', 'Every hour', 'Every four hours', 'Every eight hours',
-    'Twice daily before meals', 'Twice daily after meals'
-  ];
   aiMedicationState: AiMedicationState = 'ready';
   whyMedication: AiMedicationSuggestion | null = null;
   searchedDrug: string | null = null;
   selectedMedicines: SelectedMedicine[] = [];
-  quickMedicines = ['Paracetamol', 'Lisinopril', 'Nitrofurantoin', 'Metformin', 'Prenatal vitamins'];
-  timingOptions = ['1 - 0 - 0', '0 - 1 - 0', '0 - 0 - 1', '1 - 0 - 1', '1 - 1 - 1'];
-  dayOptions = ['3', '5', '7', '10', '15', '30'];
 
-  aiMedicationSuggestions: AiMedicationSuggestion[] = [
-    { name: 'Cetirizine', label: 'Cetirizine 100mg', likelihood: 'High', reasons: ['Fast relief from allergy symptoms.', 'Non-drowsy formula', 'Suitable for daily use'] },
-    { name: 'Zylip 150mg', label: 'Zylip 150mg', likelihood: 'High', reasons: ['Matches the suggested diagnosis', 'Well tolerated at this dose'] },
-    { name: 'Azicip 500mg', label: 'Azicip 500mg', likelihood: 'Moderate', reasons: ['Covers likely bacterial cause', 'Short course option'] },
-    { name: 'Dolo 500mg', label: 'Dolo 500mg', likelihood: 'Less', reasons: ['Symptomatic fever relief only'] }
-  ];
+  aiMedicationSuggestions: AiMedicationSuggestion[] = [...DEFAULT_AI_MEDICATION_SUGGESTIONS];
 
   newMedicine: { drug: string | null; dose: string | null; frequency: string | null; durationNo: string; durationUnit: string | null; instructRemark: string | null } =
     { drug: null, dose: null, frequency: null, durationNo: '', durationUnit: null, instructRemark: null };
@@ -111,45 +102,12 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   advices: DraftAdvice[] = [];
   selectedAdvices: string[] = [];
   openBundle: AdviceBundle | null = null;
-  quickAdvices = ['Light Exercise', 'Drink 2-3 liters of water', 'Use Lukewarm water', 'Follow up in 7 days'];
-  adviceBundles: AdviceBundle[] = [
-    {
-      name: 'Pregnancy',
-      items: ['Daily fetal movement count', 'Take iron and calcium supplements regularly', 'Attend all scheduled ANC visits',
-        'Stay hydrated', 'Avoid heavy lifting', 'Sleep on your left side', 'Report vaginal bleeding immediately']
-    },
-    {
-      name: 'Hypertension',
-      items: ['Monitor BP twice daily', 'Reduce salt intake', 'Avoid smoking and alcohol', 'Light exercise 30 min daily',
-        'Take medication at same time daily']
-    },
-    {
-      name: 'Fever',
-      items: ['Drink 2-3 liters of fluids daily', 'Take complete bed rest for 3-5 days', 'Monitor temperature twice daily',
-        'Use lukeward water', 'Return if fever exceeds 103°F']
-    },
-    {
-      name: 'Diabetes',
-      items: ['Monitor blood glucose daily', 'Avoid high-sugar foods', 'Walk 30 minutes daily after meals',
-        'Maintain regular meal timing', 'Inspect feet daily for cuts']
-    },
-    {
-      name: 'Lifestyle',
-      items: ['Stay hydrated', 'Take adequate rest', 'Light exercise 30 min daily', 'Eat balanced diet', 'Get 7-8 hours sleep']
-    },
-    {
-      name: 'Follow-up',
-      items: ['Follow up in 5-7 days', 'Complete medication course', 'Report if symptoms worsen', 'Schedule next appointment']
-    }
-  ];
 
   newTestText: string | null = null;
   testOptions: string[] = [];
   tests: DraftTest[] = [];
 
   referralSpecialityOptions: string[] = [];
-  facilityOptions: string[] = facility.facilities.map(f => f.name);
-  referralPriorities: string[] = refer_prioritie.refer_priorities.map(p => p.name);
   newReferral: { speciality: string | null; facility: string | null; priority: string | null; reason: string } =
     { speciality: null, facility: null, priority: null, reason: '' };
   referrals: DraftReferral[] = [];
@@ -195,9 +153,9 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   ngOnInit(): void {
     this.diagnosisSearch$.pipe(
-      debounceTime(300),
+      debounceTime(DIAGNOSIS_SEARCH_DEBOUNCE_MS),
       distinctUntilChanged(),
-      switchMap(term => term && term.length >= 3 ? this.v2Service.searchDiagnosis(term) : of([]))
+      switchMap(term => term && term.length >= DIAGNOSIS_SEARCH_MIN_LENGTH ? this.v2Service.searchDiagnosis(term) : of([]))
     ).subscribe(results => { this.diagnosisResults = results; });
 
     this.v2Service.getAdvicesList().subscribe(list => { this.adviceOptions = list; });
@@ -253,13 +211,13 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.toggleSelectedDiagnosis(name, 'manual');
   }
 
-  private toggleSelectedDiagnosis(name: string, source: 'ai' | 'manual', code = 'NA'): void {
+  private toggleSelectedDiagnosis(name: string, source: 'ai' | 'manual', code = DEFAULT_DIAGNOSIS_CODE): void {
     const index = this.selectedDiagnoses.findIndex(d => d.name.toLowerCase() === name.toLowerCase());
     if (index > -1) {
       this.selectedDiagnoses.splice(index, 1);
       return;
     }
-    this.selectedDiagnoses.push({ name, code, source, type: 'Primary', status: 'Provisional' });
+    this.selectedDiagnoses.push({ name, code, source, type: DEFAULT_DIAGNOSIS_TYPE, status: DEFAULT_DIAGNOSIS_STATUS });
   }
 
   toggleWhy(suggestion: AiDiagnosisSuggestion, event: Event): void {
@@ -269,7 +227,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   onDiagnosisPicked(option: DiagnosisOption | null): void {
     if (!option?.name) { return; }
-    this.toggleSelectedDiagnosis(option.name, 'manual', option.code || 'NA');
+    this.toggleSelectedDiagnosis(option.name, 'manual', option.code || DEFAULT_DIAGNOSIS_CODE);
     this.selectedDiagnosis = null;
   }
 
@@ -280,7 +238,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   submitSelectedDiagnoses(): void {
     if (!this.canWrite()) { return; }
     [...this.selectedDiagnoses].forEach(dx => {
-      const payload = { name: dx.name, type: dx.type, status: dx.status, code: dx.code || 'NA' };
+      const payload = { name: dx.name, type: dx.type, status: dx.status, code: dx.code || DEFAULT_DIAGNOSIS_CODE };
       this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, payload).subscribe(res => {
         this.addedDiagnoses.push({ ...payload, uuid: res?.uuid || '' });
         const index = this.selectedDiagnoses.findIndex(d => d.name === dx.name);
@@ -305,7 +263,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   updateAiSuggestions(): void {
     this.aiDiagnosisState = 'loading';
     this.whySuggestion = null;
-    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, 1500);
+    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, AI_SUGGESTION_DELAY_MS);
   }
 
   addDiagnosisManually(): void {
@@ -316,7 +274,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   retryAiDiagnosis(): void {
     this.aiDiagnosisState = 'loading';
-    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, 1500);
+    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, AI_SUGGESTION_DELAY_MS);
   }
 
   addDiagnosis(): void {
@@ -325,7 +283,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
       name: this.selectedDiagnosis.name,
       type: this.newDiagnosisType,
       status: this.newDiagnosisStatus,
-      code: this.selectedDiagnosis.code || 'NA'
+      code: this.selectedDiagnosis.code || DEFAULT_DIAGNOSIS_CODE
     };
     this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, dx, this.editDiagnosisUuid || undefined).subscribe(res => {
       const item = { ...dx, uuid: res?.uuid || this.editDiagnosisUuid };
@@ -340,7 +298,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   editDiagnosis(index: number): void {
     const dx = this.addedDiagnoses[index];
-    this.selectedDiagnosis = { name: dx.name, code: dx.code || 'NA' };
+    this.selectedDiagnosis = { name: dx.name, code: dx.code || DEFAULT_DIAGNOSIS_CODE };
     this.diagnosisResults = [this.selectedDiagnosis];
     this.newDiagnosisType = dx.type;
     this.newDiagnosisStatus = dx.status;
@@ -351,8 +309,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   cancelDiagnosis(): void {
     this.selectedDiagnosis = null;
     this.diagnosisResults = [];
-    this.newDiagnosisType = 'Primary';
-    this.newDiagnosisStatus = 'Provisional';
+    this.newDiagnosisType = DEFAULT_DIAGNOSIS_TYPE;
+    this.newDiagnosisStatus = DEFAULT_DIAGNOSIS_STATUS;
     this.editDiagnosisIndex = -1;
     this.editDiagnosisUuid = '';
   }
@@ -425,7 +383,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
         dose: m.strength,
         frequency: m.timing,
         durationNo: m.days,
-        durationUnit: 'Days',
+        durationUnit: DEFAULT_MEDICINE_DURATION_UNIT,
         instructRemark: m.remarks
       };
       this.v2Service.saveMedication(this.patientUuid, this.visitNoteUuid, med).subscribe(res => {
@@ -443,7 +401,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   retryAiMedication(): void {
     this.aiMedicationState = 'loading';
-    setTimeout(() => { this.aiMedicationState = 'ready'; }, 1500);
+    setTimeout(() => { this.aiMedicationState = 'ready'; }, AI_SUGGESTION_DELAY_MS);
   }
 
   addMedicine(): void {

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
@@ -1,0 +1,91 @@
+import { facility, refer_prioritie } from 'src/config/constant';
+import medicines from 'src/app/core/data/medicines';
+import doses from 'src/app/core/data/dose';
+import durationUnits from 'src/app/core/data/durationUnitList';
+import instructionRemarks from 'src/app/core/data/instructionRemarks';
+import { AdviceBundle, AiDiagnosisSuggestion, AiMedicationSuggestion, AyuSuggestedQuestion } from '../visit-summary-v2.models';
+
+export const AI_SUGGESTION_DELAY_MS = 1500;
+export const DIAGNOSIS_SEARCH_DEBOUNCE_MS = 300;
+export const DIAGNOSIS_SEARCH_MIN_LENGTH = 3;
+export const DEFAULT_DIAGNOSIS_CODE = 'NA';
+export const DEFAULT_DIAGNOSIS_TYPE = 'Primary';
+export const DEFAULT_DIAGNOSIS_STATUS = 'Provisional';
+export const DEFAULT_MEDICINE_DURATION_UNIT = 'Days';
+
+export const CONTEXT_CHIPS: string[] = ['Pregnancy', 'Travel History', 'Immunocompromised', 'Weight Loss', 'Chronic Disease'];
+export const DIAGNOSIS_TYPES: string[] = ['Primary', 'Secondary'];
+export const DIAGNOSIS_STATUSES: string[] = ['Provisional', 'Confirmed', 'Under Evaluation'];
+export const QUICK_DIAGNOSES: string[] = ['Viral Fever', 'Hypertension', 'UTI', 'Diabetes', 'Pregnancy'];
+
+export const DRUG_OPTIONS: string[] = medicines.map(m => m.name);
+export const DOSE_OPTIONS: string[] = doses.map(d => d.name);
+export const DURATION_UNIT_OPTIONS: string[] = durationUnits.map(u => u.name);
+export const INSTRUCTION_OPTIONS: string[] = instructionRemarks.map(i => i.name);
+export const FACILITY_OPTIONS: string[] = facility.facilities.map(f => f.name);
+export const REFERRAL_PRIORITIES: string[] = refer_prioritie.refer_priorities.map(p => p.name);
+
+export const FREQUENCY_OPTIONS: string[] = [
+  'Once daily', 'Twice daily', 'Three times daily', 'Four times daily',
+  'Every 30 minutes', 'Every hour', 'Every four hours', 'Every eight hours',
+  'Twice daily before meals', 'Twice daily after meals'
+];
+export const QUICK_MEDICINES: string[] = ['Paracetamol', 'Lisinopril', 'Nitrofurantoin', 'Metformin', 'Prenatal vitamins'];
+export const TIMING_OPTIONS: string[] = ['1 - 0 - 0', '0 - 1 - 0', '0 - 0 - 1', '1 - 0 - 1', '1 - 1 - 1'];
+export const DAY_OPTIONS: string[] = ['3', '5', '7', '10', '15', '30'];
+
+export const QUICK_ADVICES: string[] = ['Light Exercise', 'Drink 2-3 liters of water', 'Use Lukewarm water', 'Follow up in 7 days'];
+
+export const ADVICE_BUNDLES: AdviceBundle[] = [
+  {
+    name: 'Pregnancy',
+    items: ['Daily fetal movement count', 'Take iron and calcium supplements regularly', 'Attend all scheduled ANC visits',
+      'Stay hydrated', 'Avoid heavy lifting', 'Sleep on your left side', 'Report vaginal bleeding immediately']
+  },
+  {
+    name: 'Hypertension',
+    items: ['Monitor BP twice daily', 'Reduce salt intake', 'Avoid smoking and alcohol', 'Light exercise 30 min daily',
+      'Take medication at same time daily']
+  },
+  {
+    name: 'Fever',
+    items: ['Drink 2-3 liters of fluids daily', 'Take complete bed rest for 3-5 days', 'Monitor temperature twice daily',
+      'Use lukeward water', 'Return if fever exceeds 103°F']
+  },
+  {
+    name: 'Diabetes',
+    items: ['Monitor blood glucose daily', 'Avoid high-sugar foods', 'Walk 30 minutes daily after meals',
+      'Maintain regular meal timing', 'Inspect feet daily for cuts']
+  },
+  {
+    name: 'Lifestyle',
+    items: ['Stay hydrated', 'Take adequate rest', 'Light exercise 30 min daily', 'Eat balanced diet', 'Get 7-8 hours sleep']
+  },
+  {
+    name: 'Follow-up',
+    items: ['Follow up in 5-7 days', 'Complete medication course', 'Report if symptoms worsen', 'Schedule next appointment']
+  }
+];
+
+export const DEFAULT_AI_CLINICAL_SUMMARY = 'The most likely diagnoses for this patient are Urinary Tract Infection (UTI), Viral Fever, and Anemia, given the symptoms of burning sensation during urination, prolonged fever with chills and night sweats, and signs of anemia like pale pallor and pale nails. These conditions are common in rural India and can be managed with appropriate treatment. The presence of significant vital sign abnormalities suggests the need for further evaluation.';
+
+export const DEFAULT_AI_DIAGNOSIS_SUGGESTIONS: AiDiagnosisSuggestion[] = [
+  { name: 'Dengue', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
+  { name: 'Viral Fever', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
+  { name: 'URI', likelihood: 'Moderate', reasons: ['Sore throat reported', 'Nasal congestion'] },
+  { name: 'Malaria', likelihood: 'Less', reasons: ['Fever with chills', 'Endemic area'] },
+  { name: 'Typhiod', likelihood: 'Less', reasons: ['Prolonged fever', 'Abdominal discomfort'] }
+];
+
+export const DEFAULT_AI_MEDICATION_SUGGESTIONS: AiMedicationSuggestion[] = [
+  { name: 'Cetirizine', label: 'Cetirizine 100mg', likelihood: 'High', reasons: ['Fast relief from allergy symptoms.', 'Non-drowsy formula', 'Suitable for daily use'] },
+  { name: 'Zylip 150mg', label: 'Zylip 150mg', likelihood: 'High', reasons: ['Matches the suggested diagnosis', 'Well tolerated at this dose'] },
+  { name: 'Azicip 500mg', label: 'Azicip 500mg', likelihood: 'Moderate', reasons: ['Covers likely bacterial cause', 'Short course option'] },
+  { name: 'Dolo 500mg', label: 'Dolo 500mg', likelihood: 'Less', reasons: ['Symptomatic fever relief only'] }
+];
+
+export const DEFAULT_AYU_SUGGESTED_QUESTIONS: AyuSuggestedQuestion[] = [
+  { category: 'Symptom Timing', question: 'Does the patient experience headaches more in the morning or evening?', answer: 'No' },
+  { category: 'Associated Symptoms', question: 'Is there any visual disturbance (blurred vision, seeing spots)?', answer: 'Seeing Spots', editing: true },
+  { category: 'Clinical Signs', question: 'Has the patient noticed sudden weight gain in the past week?', answer: '' }
+];

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.html
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.html
@@ -60,6 +60,7 @@
           <app-doctor-note
             *ngIf="visitNoteStarted"
             [patientUuid]="patientUuid"
+            [patientPhoneNo]="patient?.contactNo"
             [visitUuid]="visitId"
             [visitNoteUuid]="visitNoteUuid">
           </app-doctor-note>

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
@@ -823,6 +823,864 @@ app-past-visits {
   }
 }
 
+.vs2-btn-soft {
+  background: $purple-soft;
+  color: $purple;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 24px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  margin-top: 4px;
+
+  &:hover {
+    background: darken($purple-soft, 4%);
+  }
+}
+
+.vs2-ayu-card {
+  background: $purple-soft;
+  border: 1.5px solid $purple;
+  border-radius: 12px;
+  margin-bottom: 18px;
+  overflow: hidden;
+}
+
+.vs2-ayu-banner {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  cursor: pointer;
+
+  .vs2-ayu-icon {
+    width: 32px;
+    height: 32px;
+  }
+
+  .vs2-ayu-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+  }
+
+  .vs2-ayu-title {
+    font-size: 17px;
+    font-weight: 700;
+    color: $navy;
+  }
+
+  .vs2-ayu-subtitle {
+    font-size: 13px;
+    color: $grey-text;
+  }
+
+  .vs2-ayu-chevron {
+    color: $navy;
+  }
+}
+
+.vs2-ayu-body {
+  padding: 0 18px 18px;
+}
+
+.vs2-ayu-hint {
+  background: #fbfaff;
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-size: 13px;
+  color: $navy;
+  margin-bottom: 14px;
+
+  b {
+    color: $purple;
+  }
+}
+
+.vs2-ayu-question {
+  background: #fff;
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
+}
+
+.vs2-ayu-q-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.vs2-ayu-tag {
+  background: $purple-soft;
+  color: $purple;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.vs2-ayu-q-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.vs2-ayu-yes,
+.vs2-ayu-no,
+.vs2-ayu-add {
+  border: none;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.vs2-ayu-yes {
+  background: $green-soft;
+  color: #1f9d6e;
+}
+
+.vs2-ayu-no {
+  background: $red-soft;
+  color: $red;
+}
+
+.vs2-ayu-add {
+  background: #f3f0ff;
+  color: $purple;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.vs2-ayu-edit {
+  color: $purple;
+  cursor: pointer;
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+}
+
+.vs2-ayu-q-text {
+  font-size: 14px;
+  color: $navy;
+  margin: 0 0 4px;
+}
+
+.vs2-ayu-answer {
+  font-size: 14px;
+  font-weight: 700;
+  color: $purple;
+}
+
+.vs2-ayu-answer-input {
+  margin-top: 4px;
+}
+
+.vs2-ayu-refine-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: $purple;
+  margin: 16px 0 2px;
+}
+
+.vs2-ayu-refine-sub {
+  font-size: 12px;
+  color: $grey-text;
+  margin: 0 0 10px;
+}
+
+.vs2-ayu-refine {
+  background: #fbfaff;
+  border: none;
+}
+
+.vs2-ayu-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 14px;
+}
+
+.vs2-interaction-list li {
+  margin-bottom: 4px;
+}
+
+.vs2-connect-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.vs2-icon-circle {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: $green;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 18px;
+    height: 18px;
+    filter: brightness(0) invert(1);
+  }
+
+  &.vs2-icon-circle-disabled {
+    background: $grey-soft;
+    pointer-events: none;
+
+    img {
+      filter: brightness(0) invert(0.7);
+    }
+  }
+}
+
+.vs2-connect-hint {
+  font-size: 14px;
+  color: $grey-text;
+  margin-left: 4px;
+}
+
+.vs2-radio-green input {
+  accent-color: $green;
+}
+
+
+
+.vs2-summary-text {
+  padding: 0 18px 16px;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.7;
+  color: $navy;
+}
+
+.vs2-ai-dx-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 700;
+  color: $purple;
+  margin: 0 0 12px;
+
+  img {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.vs2-ai-panel {
+  background: $section-bg;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.vs2-ai-loading-head,
+.vs2-ai-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 14px;
+
+  div {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.vs2-ai-loading-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: $purple;
+}
+
+.vs2-ai-loading-sub,
+.vs2-ai-error-sub {
+  font-size: 12px;
+  color: $grey-text;
+}
+
+.vs2-ai-error-icon {
+  color: $red;
+}
+
+.vs2-ai-error-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: $red;
+}
+
+.vs2-ai-error-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.vs2-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.vs2-skeleton-chip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.vs2-skeleton-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: $grey-soft;
+  flex: none;
+}
+
+.vs2-skeleton-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+
+  i {
+    height: 7px;
+    border-radius: 4px;
+    background: $grey-soft;
+
+    &:first-child {
+      width: 55%;
+    }
+
+    &:last-child {
+      width: 80%;
+    }
+  }
+}
+
+.vs2-ai-disclaimer {
+  background: #fffdf3;
+  border: 1px solid #f5e6b8;
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: #8a6d1f;
+  margin-bottom: 16px;
+
+  b {
+    color: #7a5c12;
+  }
+}
+
+.vs2-dx-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.vs2-dx-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid $border;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 15px;
+  color: $navy;
+  cursor: pointer;
+  background: #fff;
+
+  .vs2-dx-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: $grey-text;
+  }
+
+  .vs2-dx-badge {
+    border-radius: 6px;
+    padding: 3px 8px;
+    font-size: 12px;
+    font-weight: 700;
+    background: $grey-soft;
+    color: $grey-text;
+  }
+
+  .vs2-dx-info,
+  .vs2-dx-check {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: $grey-text;
+  }
+
+  &.vs2-dx-high {
+    border-color: #bdeedd;
+
+    .vs2-dx-dot { background: $green; }
+    .vs2-dx-badge { background: $green-soft; color: #1f9d6e; }
+  }
+
+  &.vs2-dx-moderate {
+    border-color: #f6d9a8;
+
+    .vs2-dx-dot { background: #e79a2b; }
+    .vs2-dx-badge { background: #fff4e2; color: #c2760f; }
+  }
+
+  &.vs2-dx-selected {
+    border-color: $green;
+
+    .vs2-dx-check { color: $green; }
+  }
+}
+
+.vs2-dx-why {
+  background: $section-bg;
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 16px;
+
+  h5 {
+    font-size: 14px;
+    font-weight: 700;
+    color: $purple;
+    margin: 0 0 8px;
+  }
+}
+
+.vs2-dx-search {
+  display: block;
+  margin-bottom: 12px;
+
+  .ng-select-container {
+    background: $section-bg;
+    min-height: 46px;
+  }
+}
+
+.vs2-dx-quick-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.vs2-dx-quick {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: 999px;
+  padding: 7px 14px;
+  font-size: 14px;
+  color: $navy;
+  cursor: pointer;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: $grey-text;
+  }
+
+  &.vs2-dx-quick-on {
+    border-color: $green;
+    color: $green;
+
+    mat-icon {
+      color: $green;
+    }
+  }
+}
+
+.vs2-selected-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: $purple;
+  margin: 0 0 12px;
+}
+
+.vs2-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: $purple-soft;
+  color: $purple;
+  font-size: 12px;
+  margin-left: 6px;
+}
+
+.vs2-dx-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid $green;
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+
+  .vs2-dx-row-check {
+    color: $green;
+  }
+
+  .vs2-dx-row-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: $navy;
+    min-width: 90px;
+  }
+}
+
+.vs2-dx-source {
+  background: $grey-soft;
+  color: $grey-text;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  margin-right: auto;
+
+  &.vs2-dx-source-ai {
+    background: #eaf1ff;
+    color: #2f6fe4;
+  }
+}
+
+.vs2-segmented {
+  display: inline-flex;
+  gap: 6px;
+  padding-left: 12px;
+  border-left: 1px solid $border;
+
+  button {
+    border: none;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    background: transparent;
+    color: $grey-text;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .vs2-seg-type.vs2-seg-on {
+    background: $green-soft;
+    color: #1f9d6e;
+  }
+
+  .vs2-seg-status.vs2-seg-on {
+    background: #fff4e2;
+    color: #c2760f;
+  }
+}
+
+.vs2-btn-outline {
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 700;
+  color: $navy;
+  cursor: pointer;
+}
+
+.vs2-btn-block {
+  width: 100%;
+  background: $purple;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 14px;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:hover {
+    background: darken($purple, 6%);
+  }
+}
+
+
+
+.vs2-ai-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 28px 16px;
+}
+
+.vs2-ai-empty-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: $red-soft;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+
+  img {
+    width: 22px;
+    height: 22px;
+  }
+}
+
+.vs2-ai-empty-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: $purple;
+  margin-bottom: 6px;
+}
+
+.vs2-ai-empty-sub {
+  font-size: 13px;
+  line-height: 1.6;
+  color: $grey-text;
+}
+
+.vs2-med-card {
+  border: 1px solid $green;
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 14px;
+}
+
+.vs2-med-card-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.vs2-med-card-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+
+  mat-icon {
+    cursor: pointer;
+  }
+}
+
+.vs2-confirm-icon {
+  color: $green;
+}
+
+.vs2-cancel-icon {
+  color: $grey-text;
+}
+
+.vs2-med-card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px 16px;
+  align-items: center;
+}
+
+.vs2-med-col-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: $navy;
+}
+
+.vs2-med-col-value {
+  font-size: 14px;
+  color: $navy;
+}
+
+
+
+.vs2-improve {
+  margin-bottom: 18px;
+}
+
+.vs2-improve-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+
+  img {
+    width: 20px;
+    height: 20px;
+  }
+
+  mat-icon {
+    margin-left: auto;
+    color: $navy;
+  }
+}
+
+.vs2-improve-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: $purple;
+
+  em {
+    font-style: normal;
+    font-weight: 400;
+    color: $navy;
+  }
+}
+
+.vs2-improve-sub {
+  font-size: 12.5px;
+  color: $grey-text;
+  margin: 2px 0 10px;
+}
+
+.vs2-improve-text {
+  background: $section-bg;
+  border: none;
+  margin-bottom: 12px;
+}
+
+.vs2-btn-block:disabled {
+  background: $purple-soft;
+  color: #a9a4c4;
+  cursor: not-allowed;
+}
+
+
+.vs2-bundle-title {
+  margin-bottom: 14px;
+}
+
+.vs2-bundle-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.vs2-bundle {
+  position: relative;
+}
+
+.vs2-bundle-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 14px;
+  color: $navy;
+  cursor: pointer;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: $grey-text;
+  }
+
+  &.vs2-bundle-chip-open {
+    border-color: $purple;
+  }
+}
+
+.vs2-bundle-panel {
+  position: absolute;
+  z-index: 5;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 280px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(29, 27, 58, 0.16);
+  padding: 8px 0 10px;
+}
+
+.vs2-bundle-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px 10px;
+  font-size: 15px;
+  color: $navy;
+
+  mat-icon {
+    color: $grey-text;
+    cursor: pointer;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.vs2-bundle-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 9px 16px;
+  font-size: 14px;
+  color: $navy;
+  text-align: left;
+  cursor: pointer;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: $grey-text;
+    flex: none;
+  }
+
+  &:hover {
+    background: $section-bg;
+  }
+
+  &.vs2-bundle-item-on {
+    background: $section-bg;
+
+    mat-icon {
+      color: $purple;
+    }
+  }
+}
+
+.vs2-advice-list {
+  margin-bottom: 18px;
+
+  li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding-right: 4px;
+  }
+}
+
 .vs2-dn-header {
   margin-top: 32px;
   padding-top: 20px;

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.ts
@@ -3,7 +3,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PatientModel, VisitModel } from 'src/app/model/model';
 import { doctorDetails, visitTypes } from 'src/config/constant';
-import { getCacheData } from 'src/app/utils/utility-functions';
+import { deleteCacheData, getCacheData, setCacheData } from 'src/app/utils/utility-functions';
 import { CoreService } from 'src/app/services/core/core.service';
 import { AppConfigService } from 'src/app/services/app-config.service';
 import { AnalyticsService } from 'src/app/services/analytics.service';
@@ -138,6 +138,7 @@ export class VisitSummaryV2Component implements OnInit, OnDestroy {
       this.chatDialogRef.close();
       this.chatDialogRef = undefined;
     }
+    deleteCacheData(visitTypes.PATIENT_VISIT_PROVIDER);
   }
 
   get canStartCall(): boolean {
@@ -261,8 +262,18 @@ export class VisitSummaryV2Component implements OnInit, OnDestroy {
     this.abdomenFindings = data.abdomenFindings;
     this.eyeImages = data.eyeImages;
     this.documents = data.documents;
+    this.cacheVisitProvider(this.visit);
     this.checkOpenChatBoxFlag();
     this.loadPastVisits();
+  }
+
+
+  private cacheVisitProvider(visit: VisitModel): void {
+    const encounter = (visit?.encounters || []).find(e => e.display?.match(visitTypes.ADULTINITIAL) !== null);
+    const visitProvider = encounter?.encounterProviders?.[0];
+    if (visitProvider) {
+      setCacheData(visitTypes.PATIENT_VISIT_PROVIDER, JSON.stringify(visitProvider));
+    }
   }
 
   private loadPastVisits(): void {

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
@@ -100,3 +100,54 @@ export interface Patient {
   address: DetailRow[];
   other: DetailRow[];
 }
+
+export type AiDiagnosisState = 'loading' | 'error' | 'ready';
+
+export type AiMedicationState = 'loading' | 'error' | 'no-diagnosis' | 'ready';
+
+export type SuggestionLikelihood = 'High' | 'Moderate' | 'Less';
+
+export type SuggestionSource = 'ai' | 'manual';
+
+export interface AiDiagnosisSuggestion {
+  name: string;
+  likelihood: SuggestionLikelihood;
+  reasons: string[];
+}
+
+export interface AiMedicationSuggestion {
+  name: string;
+  label: string;
+  likelihood: SuggestionLikelihood;
+  reasons: string[];
+}
+
+export interface SelectedDiagnosis {
+  name: string;
+  code: string;
+  source: SuggestionSource;
+  type: string;
+  status: string;
+}
+
+export interface SelectedMedicine {
+  drug: string;
+  source: SuggestionSource;
+  timing: string;
+  strength: string;
+  days: string;
+  remarks: string;
+  editing?: boolean;
+}
+
+export interface AyuSuggestedQuestion {
+  category: string;
+  question: string;
+  answer: string;
+  editing?: boolean;
+}
+
+export interface AdviceBundle {
+  name: string;
+  items: string[];
+}


### PR DESCRIPTION

Rebuild the Patient interaction, Diagnosis, Medication and Advice
sections of the v2 doctor's note around AI suggestions:

- Patient interaction: collapsible Ayu Suggested Questions panel with
  per-question Yes/No/free-text answers and a refine-suggestions note
- Diagnosis: collapsible AI clinical summary, likelihood-ranked
  suggestion chips with rationale, quick picks and a staged Selected
  Diagnosis list with type/status segments
- Medication: likelihood-ranked suggestion chips with rationale and
  staged Selected Medication rows editable inline (timing, strength,
  days, remarks)
- Advice: advice bundles with per-bundle item pickers, quick picks and
  a staged advice list
- Each AI panel handles loading, error and empty states; medication
  falls back to a no-diagnosis state until a diagnosis is selected
- Cache the visit provider on load and clear it on destroy so the chat
  and video call modals can resolve the health worker, matching v1
- Move the new UI types into visit-summary-v2.models.ts
