### PR TITLE
feat: integrate AI diagnosis and treatment APIs in visit summary v2

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -50,6 +50,7 @@ import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 
 //Regular Imports
 import { environment } from "../environments/environment";
+import { ENVIRONMENT } from "aiddx-library";
 import { SocketService } from "./services/socket.service";
 import { AppRoutingModule } from './app-routing.module';
 import { NetworkInterceptor } from "./core/interceptors/network.interceptor";
@@ -197,6 +198,7 @@ registerLocaleData(localeEn);
     },
     CookieService,
     SocketService,
+    { provide: ENVIRONMENT, useValue: environment },
     { provide: APP_BASE_HREF, useValue: "/" },
     { provide: LocationStrategy, useClass: HashLocationStrategy },
     { provide: MAT_DIALOG_DATA, useValue: {} },

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
@@ -26,9 +26,24 @@
         💡 <b>Ayu AI:</b> These questions help fill diagnostic gaps. Answer what you know—skip the rest.
       </div>
 
+      <div class="vs2-ayu-status" *ngIf="aiDiagnosisState === 'loading'">
+        <mat-spinner diameter="18"></mat-spinner>
+        <span>Fetching suggested questions..</span>
+      </div>
+
+      <div class="vs2-ayu-status vs2-ayu-status-error" *ngIf="aiDiagnosisState === 'error'">
+        <mat-icon>error</mat-icon>
+        <span>We couldn't fetch the suggested questions.</span>
+        <button class="vs2-ayu-add" (click)="retryAiDiagnosis()">Try again</button>
+      </div>
+
+      <div class="vs2-ayu-status" *ngIf="aiDiagnosisState === 'ready' && !ayuSuggestedQuestions.length">
+        <span>No suggested questions for this visit.</span>
+      </div>
+
       <div class="vs2-ayu-question" *ngFor="let q of ayuSuggestedQuestions; let i = index">
         <div class="vs2-ayu-q-top">
-          <span class="vs2-ayu-tag">{{ q.category }}</span>
+          <span class="vs2-ayu-tag" *ngIf="q.category">{{ q.category }}</span>
           <span class="vs2-ayu-q-actions">
             <ng-container *ngIf="!q.answer && !q.editing">
               <button class="vs2-ayu-yes" (click)="answerAyuQuestion(q, 'Yes')">Yes</button>
@@ -39,6 +54,7 @@
           </span>
         </div>
         <p class="vs2-ayu-q-text">{{ q.question }}</p>
+        <p class="vs2-ayu-q-hint" *ngIf="q.hint">{{ q.hint }}</p>
         <input class="vs2-input vs2-ayu-answer-input" *ngIf="q.editing" [(ngModel)]="q.answer"
           [ngModelOptions]="{ standalone: true }" placeholder="Type your answer"
           (blur)="q.editing = false" (keyup.enter)="q.editing = false" />
@@ -462,6 +478,16 @@
   </div>
   <div class="vs2-divider"></div>
 
+  <ng-container *ngIf="aiAdvices.length">
+    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Advice</h4>
+    <div class="vs2-dx-quick-row">
+      <button class="vs2-dx-quick" *ngFor="let a of aiAdvices" [class.vs2-dx-quick-on]="isAdviceSelected(a)"
+        (click)="toggleAdvice(a)">
+        <mat-icon>{{ isAdviceSelected(a) ? 'check' : 'add' }}</mat-icon> {{ a }}
+      </button>
+    </div>
+  </ng-container>
+
   <h4 class="vs2-selected-title vs2-bundle-title">Advice Bundles</h4>
 
   <div class="vs2-bundle-row">
@@ -526,6 +552,16 @@
   </div>
   <div class="vs2-divider"></div>
 
+  <ng-container *ngIf="aiTests.length">
+    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Tests</h4>
+    <div class="vs2-dx-quick-row">
+      <button class="vs2-dx-quick" *ngFor="let t of aiTests" [class.vs2-dx-quick-on]="isTestAdded(t)"
+        (click)="addAiTest(t)">
+        <mat-icon>{{ isTestAdded(t) ? 'check' : 'add' }}</mat-icon> {{ t }}
+      </button>
+    </div>
+  </ng-container>
+
   <div class="vs2-list-item" *ngFor="let t of tests; let i = index">
     <span class="vs2-detail-label">{{ t.value }}</span>
     <mat-icon class="vs2-delete-icon" (click)="deleteTest(i, t.uuid)">delete_outline</mat-icon>
@@ -554,6 +590,15 @@
     <mat-icon class="vs2-chevron">expand_less</mat-icon>
   </div>
   <div class="vs2-divider"></div>
+
+  <ng-container *ngIf="aiReferrals.length">
+    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Referral</h4>
+    <div class="vs2-dx-quick-row">
+      <button class="vs2-dx-quick" *ngFor="let r of aiReferrals" (click)="applyAiReferral(r)">
+        <mat-icon>add</mat-icon> {{ r.speciality }}<ng-container *ngIf="r.facility"> - {{ r.facility }}</ng-container>
+      </button>
+    </div>
+  </ng-container>
 
   <div class="vs2-med-grid vs2-ref-grid">
     <div class="vs2-field">
@@ -627,6 +672,13 @@
     <mat-icon class="vs2-chevron">expand_less</mat-icon>
   </div>
   <div class="vs2-divider"></div>
+
+  <div class="vs2-ai-followup" *ngIf="aiFollowUp">
+    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Follow-up</h4>
+    <button class="vs2-dx-quick" (click)="applyAiFollowUp()">
+      <mat-icon>add</mat-icon> {{ aiFollowUp.duration }}<ng-container *ngIf="aiFollowUp.reason"> - {{ aiFollowUp.reason }}</ng-container>
+    </button>
+  </div>
 
   <div class="vs2-table vs2-fu-note-table" *ngIf="followUpUuid">
     <div class="vs2-table-head">

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
@@ -4,18 +4,18 @@ import { Subject, of } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { doctorDetails } from 'src/config/constant';
 import { getCacheData } from 'src/app/utils/utility-functions';
+import { PatientModel, VisitModel } from 'src/app/model/model';
 import { CoreService } from 'src/app/services/core/core.service';
 import {
   DiagnosisOption, DraftAdvice, DraftDiagnosis, DraftMedication, DraftReferral,
   DraftTest, DraftTextItem, VisitSummaryV2Service
 } from '../visit-summary-v2.service';
 import {
-  AdviceBundle, AiDiagnosisState, AiDiagnosisSuggestion, AiMedicationState, AiMedicationSuggestion,
+  AdviceBundle, AiDiagnosisState, AiDiagnosisSuggestion, AiFollowUp, AiMedicationState, AiMedicationSuggestion,
   AyuSuggestedQuestion, SelectedDiagnosis, SelectedMedicine
 } from '../visit-summary-v2.models';
 import {
-  ADVICE_BUNDLES, AI_SUGGESTION_DELAY_MS, CONTEXT_CHIPS, DAY_OPTIONS, DEFAULT_AI_CLINICAL_SUMMARY,
-  DEFAULT_AI_DIAGNOSIS_SUGGESTIONS, DEFAULT_AI_MEDICATION_SUGGESTIONS, DEFAULT_AYU_SUGGESTED_QUESTIONS,
+  ADVICE_BUNDLES, CONTEXT_CHIPS, DAY_OPTIONS,
   DEFAULT_DIAGNOSIS_CODE, DEFAULT_DIAGNOSIS_STATUS, DEFAULT_DIAGNOSIS_TYPE, DEFAULT_MEDICINE_DURATION_UNIT,
   DIAGNOSIS_SEARCH_DEBOUNCE_MS, DIAGNOSIS_SEARCH_MIN_LENGTH, DIAGNOSIS_STATUSES, DIAGNOSIS_TYPES,
   DOSE_OPTIONS, DRUG_OPTIONS, DURATION_UNIT_OPTIONS, FACILITY_OPTIONS, FREQUENCY_OPTIONS,
@@ -33,6 +33,9 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   @Input() visitUuid!: string;
   @Input() visitNoteUuid!: string;
   @Input() patientPhoneNo = '';
+  @Input() visit!: VisitModel;
+  @Input() patientInfo!: PatientModel;
+  @Input() visitCompleted = false;
 
   readonly contextChips = CONTEXT_CHIPS;
   readonly diagnosisTypes = DIAGNOSIS_TYPES;
@@ -53,12 +56,13 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   spokenToPatient = true;
   ayuQuestionsExpanded = false;
-  ayuSuggestedQuestions: AyuSuggestedQuestion[] = DEFAULT_AYU_SUGGESTED_QUESTIONS.map(q => ({ ...q }));
+  ayuSuggestedQuestions: AyuSuggestedQuestion[] = [];
   ayuRefineText = '';
+  private ayuNoteUuid = '';
 
   hasEnoughInfo = true;
 
-  aiDiagnosisState: AiDiagnosisState = 'ready';
+  aiDiagnosisState: AiDiagnosisState = 'loading';
   aiSummaryExpanded = false;
   improveExpanded = true;
   improveContextText = '';
@@ -66,8 +70,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   whySuggestion: AiDiagnosisSuggestion | null = null;
   selectedDiagnoses: SelectedDiagnosis[] = [];
 
-  aiClinicalSummary = DEFAULT_AI_CLINICAL_SUMMARY;
-  aiSuggestions: AiDiagnosisSuggestion[] = [...DEFAULT_AI_DIAGNOSIS_SUGGESTIONS];
+  aiClinicalSummary = '';
+  aiSuggestions: AiDiagnosisSuggestion[] = [];
 
   selectedDiagnosis: DiagnosisOption | null = null;
   diagnosisResults: DiagnosisOption[] = [];
@@ -87,7 +91,11 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   searchedDrug: string | null = null;
   selectedMedicines: SelectedMedicine[] = [];
 
-  aiMedicationSuggestions: AiMedicationSuggestion[] = [...DEFAULT_AI_MEDICATION_SUGGESTIONS];
+  aiMedicationSuggestions: AiMedicationSuggestion[] = [];
+  aiAdvices: string[] = [];
+  aiTests: string[] = [];
+  aiReferrals: { speciality: string; facility: string; priority: string; reason: string }[] = [];
+  aiFollowUp: AiFollowUp | null = null;
 
   newMedicine: { drug: string | null; dose: string | null; frequency: string | null; durationNo: string; durationUnit: string | null; instructRemark: string | null } =
     { drug: null, dose: null, frequency: null, durationNo: '', durationUnit: null, instructRemark: null };
@@ -149,6 +157,30 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   saveAyuQuestions(): void {
     this.ayuSuggestedQuestions.forEach(q => { q.editing = false; });
+    const notes = this.buildAyuNotes();
+    if (!notes || !this.canWrite()) { return; }
+    this.v2Service.saveInteractionNote(this.patientUuid, this.visitNoteUuid, notes, this.ayuNoteUuid).subscribe(res => {
+      this.ayuNoteUuid = res?.uuid || this.ayuNoteUuid;
+      this.loadAiDiagnosis(notes);
+    });
+  }
+
+  private buildAyuNotes(): string {
+    const answered = this.ayuSuggestedQuestions
+      .filter(q => !!q.answer)
+      .map(q => `${q.question} ${q.answer}`);
+    return [...answered, this.ayuRefineText].filter(Boolean).join('\n');
+  }
+
+  private loadInteractionNote(): void {
+    this.aiDiagnosisState = 'loading';
+    this.v2Service.loadInteractionNote(this.patientUuid, this.visitUuid).subscribe({
+      next: note => {
+        this.ayuNoteUuid = note.uuid;
+        this.loadAiDiagnosis(note.value);
+      },
+      error: () => this.loadAiDiagnosis()
+    });
   }
 
   ngOnInit(): void {
@@ -167,6 +199,9 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   ngOnChanges(changes: SimpleChanges): void {
     if ((changes['visitUuid'] || changes['patientUuid']) && this.patientUuid && this.visitUuid) {
       this.loadDraft();
+    }
+    if ((changes['visit'] || changes['patientInfo']) && this.visit && this.patientInfo) {
+      this.loadInteractionNote();
     }
   }
 
@@ -187,6 +222,9 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
         this.followUpType = draft.followUp.type || null;
         this.followUpUuid = draft.followUp.uuid;
         this.followUpTimeSlots = this.v2Service.getFollowUpTimeSlots(this.followUpDate);
+      }
+      if (this.addedDiagnoses.length) {
+        this.loadAiTreatment();
       }
     });
   }
@@ -243,7 +281,27 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
         this.addedDiagnoses.push({ ...payload, uuid: res?.uuid || '' });
         const index = this.selectedDiagnoses.findIndex(d => d.name === dx.name);
         if (index > -1) { this.selectedDiagnoses.splice(index, 1); }
+        this.loadAiTreatment();
       });
+    });
+  }
+
+  private loadAiTreatment(): void {
+    const diagnosis = this.addedDiagnoses.map(d => d.name).join(', ');
+    if (!diagnosis || !this.visit || !this.patientInfo) { return; }
+    this.aiMedicationState = 'loading';
+    this.v2Service.loadAiTreatment(this.patientInfo, this.visit, diagnosis, this.visitCompleted).subscribe({
+      next: result => {
+        this.aiMedicationSuggestions = result.medicines;
+        this.aiAdvices = result.advices;
+        this.aiTests = result.tests;
+        this.aiReferrals = result.referrals;
+        this.aiFollowUp = result.followUp;
+        this.aiMedicationState = 'ready';
+      },
+      error: () => {
+        this.aiMedicationState = 'error';
+      }
     });
   }
 
@@ -261,9 +319,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   updateAiSuggestions(): void {
-    this.aiDiagnosisState = 'loading';
     this.whySuggestion = null;
-    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, AI_SUGGESTION_DELAY_MS);
+    this.loadAiDiagnosis(this.buildAiNotes());
   }
 
   addDiagnosisManually(): void {
@@ -273,8 +330,28 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   retryAiDiagnosis(): void {
+    this.loadAiDiagnosis(this.buildAiNotes());
+  }
+
+  private buildAiNotes(): string {
+    return [this.buildAyuNotes(), this.improveContextText, ...this.selectedContextChips]
+      .filter(Boolean).join('\n');
+  }
+
+  private loadAiDiagnosis(notes = ''): void {
+    if (!this.visit || !this.patientInfo) { return; }
     this.aiDiagnosisState = 'loading';
-    setTimeout(() => { this.aiDiagnosisState = 'ready'; }, AI_SUGGESTION_DELAY_MS);
+    this.v2Service.loadAiDiagnosis(this.patientInfo, this.visit, notes, this.visitCompleted).subscribe({
+      next: result => {
+        this.aiClinicalSummary = result.summary;
+        this.aiSuggestions = result.suggestions;
+        this.ayuSuggestedQuestions = result.questions;
+        this.aiDiagnosisState = 'ready';
+      },
+      error: () => {
+        this.aiDiagnosisState = 'error';
+      }
+    });
   }
 
   addDiagnosis(): void {
@@ -334,20 +411,29 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   toggleAiMedication(suggestion: AiMedicationSuggestion): void {
-    this.toggleSelectedMedicine(suggestion.name, 'ai');
+    this.toggleSelectedMedicine(suggestion.name, 'ai', suggestion);
   }
 
   toggleQuickMedicine(name: string): void {
     this.toggleSelectedMedicine(name, 'manual');
   }
 
-  private toggleSelectedMedicine(drug: string, source: 'ai' | 'manual'): void {
+  private toggleSelectedMedicine(drug: string, source: 'ai' | 'manual', suggestion?: AiMedicationSuggestion): void {
     const index = this.selectedMedicines.findIndex(m => m.drug.toLowerCase() === drug.toLowerCase());
     if (index > -1) {
       this.selectedMedicines.splice(index, 1);
       return;
     }
-    this.selectedMedicines.push({ drug, source, timing: '', strength: '', days: '', remarks: '', editing: true });
+    this.selectedMedicines.push({
+      drug,
+      source,
+      timing: suggestion?.timing || '',
+      strength: suggestion?.strength || '',
+      days: suggestion?.days || '',
+      durationUnit: suggestion?.durationUnit || '',
+      remarks: suggestion?.remarks || '',
+      editing: !suggestion?.timing || !suggestion?.strength || !suggestion?.days
+    });
   }
 
   toggleMedicationWhy(suggestion: AiMedicationSuggestion, event: Event): void {
@@ -383,7 +469,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
         dose: m.strength,
         frequency: m.timing,
         durationNo: m.days,
-        durationUnit: DEFAULT_MEDICINE_DURATION_UNIT,
+        durationUnit: m.durationUnit || DEFAULT_MEDICINE_DURATION_UNIT,
         instructRemark: m.remarks
       };
       this.v2Service.saveMedication(this.patientUuid, this.visitNoteUuid, med).subscribe(res => {
@@ -400,8 +486,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   retryAiMedication(): void {
-    this.aiMedicationState = 'loading';
-    setTimeout(() => { this.aiMedicationState = 'ready'; }, AI_SUGGESTION_DELAY_MS);
+    this.loadAiTreatment();
   }
 
   addMedicine(): void {
@@ -493,6 +578,31 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.newAdviceText = null;
     this.selectedAdvices = [];
     this.openBundle = null;
+  }
+
+  isTestAdded(value: string): boolean {
+    return this.tests.some(t => t.value.toLowerCase() === value.toLowerCase());
+  }
+
+  addAiTest(value: string): void {
+    if (this.isTestAdded(value)) { return; }
+    this.newTestText = value;
+    this.addTest();
+  }
+
+  applyAiReferral(referral: { speciality: string; facility: string; priority: string; reason: string }): void {
+    this.newReferral = {
+      speciality: referral.speciality || null,
+      facility: referral.facility || null,
+      priority: this.newReferral.priority,
+      reason: referral.reason || ''
+    };
+  }
+
+  applyAiFollowUp(): void {
+    if (!this.aiFollowUp) { return; }
+    this.wantFollowUp = true;
+    this.followUpReason = this.aiFollowUp.reason || this.followUpReason;
   }
 
   addTest(): void {

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
@@ -3,9 +3,8 @@ import medicines from 'src/app/core/data/medicines';
 import doses from 'src/app/core/data/dose';
 import durationUnits from 'src/app/core/data/durationUnitList';
 import instructionRemarks from 'src/app/core/data/instructionRemarks';
-import { AdviceBundle, AiDiagnosisSuggestion, AiMedicationSuggestion, AyuSuggestedQuestion } from '../visit-summary-v2.models';
+import { AdviceBundle } from '../visit-summary-v2.models';
 
-export const AI_SUGGESTION_DELAY_MS = 1500;
 export const DIAGNOSIS_SEARCH_DEBOUNCE_MS = 300;
 export const DIAGNOSIS_SEARCH_MIN_LENGTH = 3;
 export const DEFAULT_DIAGNOSIS_CODE = 'NA';
@@ -67,25 +66,7 @@ export const ADVICE_BUNDLES: AdviceBundle[] = [
   }
 ];
 
-export const DEFAULT_AI_CLINICAL_SUMMARY = 'The most likely diagnoses for this patient are Urinary Tract Infection (UTI), Viral Fever, and Anemia, given the symptoms of burning sensation during urination, prolonged fever with chills and night sweats, and signs of anemia like pale pallor and pale nails. These conditions are common in rural India and can be managed with appropriate treatment. The presence of significant vital sign abnormalities suggests the need for further evaluation.';
 
-export const DEFAULT_AI_DIAGNOSIS_SUGGESTIONS: AiDiagnosisSuggestion[] = [
-  { name: 'Dengue', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
-  { name: 'Viral Fever', likelihood: 'High', reasons: ['Fever for 3 days', 'Body Ache Reported', 'Elevated Temperature (102 °F)'] },
-  { name: 'URI', likelihood: 'Moderate', reasons: ['Sore throat reported', 'Nasal congestion'] },
-  { name: 'Malaria', likelihood: 'Less', reasons: ['Fever with chills', 'Endemic area'] },
-  { name: 'Typhiod', likelihood: 'Less', reasons: ['Prolonged fever', 'Abdominal discomfort'] }
-];
+export const AI_CONFIDENCE_HIGH = 0.7;
 
-export const DEFAULT_AI_MEDICATION_SUGGESTIONS: AiMedicationSuggestion[] = [
-  { name: 'Cetirizine', label: 'Cetirizine 100mg', likelihood: 'High', reasons: ['Fast relief from allergy symptoms.', 'Non-drowsy formula', 'Suitable for daily use'] },
-  { name: 'Zylip 150mg', label: 'Zylip 150mg', likelihood: 'High', reasons: ['Matches the suggested diagnosis', 'Well tolerated at this dose'] },
-  { name: 'Azicip 500mg', label: 'Azicip 500mg', likelihood: 'Moderate', reasons: ['Covers likely bacterial cause', 'Short course option'] },
-  { name: 'Dolo 500mg', label: 'Dolo 500mg', likelihood: 'Less', reasons: ['Symptomatic fever relief only'] }
-];
-
-export const DEFAULT_AYU_SUGGESTED_QUESTIONS: AyuSuggestedQuestion[] = [
-  { category: 'Symptom Timing', question: 'Does the patient experience headaches more in the morning or evening?', answer: 'No' },
-  { category: 'Associated Symptoms', question: 'Is there any visual disturbance (blurred vision, seeing spots)?', answer: 'Seeing Spots', editing: true },
-  { category: 'Clinical Signs', question: 'Has the patient noticed sudden weight gain in the past week?', answer: '' }
-];
+export const AI_CONFIDENCE_MODERATE = 0.4;

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.html
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.html
@@ -61,6 +61,9 @@
             *ngIf="visitNoteStarted"
             [patientUuid]="patientUuid"
             [patientPhoneNo]="patient?.contactNo"
+            [visit]="visit"
+            [patientInfo]="patientModel"
+            [visitCompleted]="visitEnded"
             [visitUuid]="visitId"
             [visitNoteUuid]="visitNoteUuid">
           </app-doctor-note>

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
@@ -899,6 +899,33 @@ app-past-visits {
   }
 }
 
+.vs2-ayu-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff;
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: $grey-text;
+
+  &.vs2-ayu-status-error {
+    color: $red;
+
+    mat-icon {
+      color: $red;
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    button {
+      margin-left: auto;
+    }
+  }
+}
+
 .vs2-ayu-question {
   background: #fff;
   border-radius: 10px;
@@ -976,6 +1003,12 @@ app-past-visits {
   font-size: 14px;
   color: $navy;
   margin: 0 0 4px;
+}
+
+.vs2-ayu-q-hint {
+  font-size: 12px;
+  color: $grey-text;
+  margin: 0 0 6px;
 }
 
 .vs2-ayu-answer {

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.ts
@@ -198,7 +198,16 @@ export class VisitSummaryV2Component implements OnInit, OnDestroy {
     }
     if (!this.visit || !this.patientModel) { return; }
 
+    this.cacheVisitProvider(this.visit);
     const visitProvider = getCacheData(true, visitTypes.PATIENT_VISIT_PROVIDER);
+    if (!visitProvider?.provider?.uuid) {
+      this.coreService.openConfirmationDialog({
+        confirmationMsg: 'This visit has no health worker linked to it, so the call cannot be connected.',
+        cancelBtnText: 'Close',
+        confirmBtnText: 'Ok'
+      });
+      return;
+    }
     this.analytics.logEvent('start_call', 'engagement', 'call_button', 1, {
       doctorUserId: this.visitSummaryService.userId,
       doctorName: getCacheData(true, doctorDetails.USER)?.person?.display,

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
@@ -120,6 +120,25 @@ export interface AiMedicationSuggestion {
   label: string;
   likelihood: SuggestionLikelihood;
   reasons: string[];
+  timing?: string;
+  strength?: string;
+  days?: string;
+  durationUnit?: string;
+  remarks?: string;
+}
+
+export interface AiFollowUp {
+  required: boolean;
+  duration: string;
+  reason: string;
+}
+
+export interface AiTreatmentResult {
+  medicines: AiMedicationSuggestion[];
+  advices: string[];
+  tests: string[];
+  referrals: { speciality: string; facility: string; priority: string; reason: string }[];
+  followUp: AiFollowUp | null;
 }
 
 export interface SelectedDiagnosis {
@@ -136,6 +155,7 @@ export interface SelectedMedicine {
   timing: string;
   strength: string;
   days: string;
+  durationUnit?: string;
   remarks: string;
   editing?: boolean;
 }
@@ -143,6 +163,7 @@ export interface SelectedMedicine {
 export interface AyuSuggestedQuestion {
   category: string;
   question: string;
+  hint?: string;
   answer: string;
   editing?: boolean;
 }
@@ -150,4 +171,10 @@ export interface AyuSuggestedQuestion {
 export interface AdviceBundle {
   name: string;
   items: string[];
+}
+
+export interface AiDiagnosisResult {
+  summary: string;
+  suggestions: AiDiagnosisSuggestion[];
+  questions: AyuSuggestedQuestion[];
 }

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.service.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.service.ts
@@ -16,10 +16,13 @@ import { EncounterService } from 'src/app/services/encounter.service';
 import { LinkService } from 'src/app/services/link.service';
 import { VisitSummaryHelperService } from 'src/app/services/visit-summary-helper.service';
 import { AppConfigService } from 'src/app/services/app-config.service';
+import { AiddxService, AiTxService } from 'aiddx-library';
 import {
-  ComplaintDetail, DetailRow, DocItem, Patient, PastVisit, PrescriptionData,
+  AiDiagnosisResult, AiDiagnosisSuggestion, AiMedicationSuggestion, AiTreatmentResult, AyuSuggestedQuestion,
+  ComplaintDetail, DetailRow, DocItem, Patient, PastVisit, PrescriptionData, SuggestionLikelihood,
   SymptomGroup, TimelineGroup, VitalCell
 } from './visit-summary-v2.models';
+import { AI_CONFIDENCE_HIGH, AI_CONFIDENCE_MODERATE } from './doctor-note/doctor-note.constants';
 
 export interface DraftDiagnosis { name: string; type: string; status: string; code: string; uuid: string; }
 export interface DiagnosisOption { name: string; code: string; }
@@ -76,8 +79,127 @@ export class VisitSummaryV2Service {
     private encounterService: EncounterService,
     private linkService: LinkService,
     private helper: VisitSummaryHelperService,
-    private appConfigService: AppConfigService
+    private appConfigService: AppConfigService,
+    private aiddxService: AiddxService,
+    private aiTxService: AiTxService
   ) {}
+
+  loadInteractionNote(patientUuid: string, visitUuid: string): Observable<DraftTextItem> {
+    return this.diagnosisService.getObs(patientUuid, conceptIds.conceptNote).pipe(
+      catchError(() => of({ results: [] } as ObsApiResponseModel)),
+      map((res: ObsApiResponseModel) => {
+        const obs = (res.results || []).filter((o: ObsModel) => o.encounter?.visit?.uuid === visitUuid).pop();
+        return { value: obs?.value || '', uuid: obs?.uuid || '' };
+      })
+    );
+  }
+
+  saveInteractionNote(patientUuid: string, encounterUuid: string, value: string, existingUuid?: string): Observable<ObsModel> {
+    return this.writeObs(conceptIds.conceptNote, patientUuid, encounterUuid, value, existingUuid);
+  }
+
+  loadAiDiagnosis(patientInfo: PatientModel, visit: VisitModel, notes = '', prescriptionShared = false): Observable<AiDiagnosisResult> {
+    const casehistory = this.aiddxService.getDDxPayload(patientInfo, visit, notes);
+    return this.aiddxService.getAIDiagnosis(casehistory, visit?.uuid, prescriptionShared).pipe(
+      map((res: any) => this.buildAiDiagnosisResult(res))
+    );
+  }
+
+  private buildAiDiagnosisResult(res: any): AiDiagnosisResult {
+    const results = res?.result?.data?.result || [];
+    const questions = res?.result?.data?.further_questions || [];
+    return {
+      summary: res?.conclusion || res?.result?.data?.conclusion || '',
+      suggestions: results.map((r: any) => ({
+        name: r?.diagnosis || '',
+        likelihood: this.mapLikelihood(r?.likelihood),
+        reasons: this.buildRationale(r)
+      })).filter((s: AiDiagnosisSuggestion) => !!s.name),
+      questions: questions.map((q: any) => {
+        const key = Object.keys(q || {})[0] || '';
+        const text = q?.[key] || '';
+        const hint = text.match(/\(([^)]*)\)\s*$/);
+        return {
+          category: /^\d+$/.test(key) ? '' : key,
+          question: hint ? text.replace(hint[0], '').trim() : text,
+          hint: hint ? hint[1] : '',
+          answer: ''
+        };
+      }).filter((q: AyuSuggestedQuestion) => !!q.question)
+    };
+  }
+
+  private mapLikelihood(value: string): SuggestionLikelihood {
+    const likelihood = (value || '').toLowerCase();
+    if (likelihood.includes('high')) { return 'High'; }
+    if (likelihood.includes('moderate') || likelihood.includes('medium')) { return 'Moderate'; }
+    return 'Less';
+  }
+
+  loadAiTreatment(patientInfo: PatientModel, visit: VisitModel, diagnosis: string, prescriptionShared = false): Observable<AiTreatmentResult> {
+    const casehistory = this.aiTxService.getTxPayload(patientInfo, visit);
+    this.aiTxService.clearCache();
+    return this.aiTxService.getAITTx(casehistory, diagnosis, visit?.uuid, prescriptionShared).pipe(
+      map((res: any) => this.buildAiTreatmentResult(res))
+    );
+  }
+
+  private buildAiTreatmentResult(res: any): AiTreatmentResult {
+    const data = res?.result?.data || {};
+    return {
+      medicines: (data.medications || data.result || []).map((m: any) => ({
+        name: m?.name || '',
+        label: m?.name || '',
+        likelihood: this.mapConfidence(m?.confidence),
+        reasons: this.toReasonList(m?.rationale),
+        timing: m?.frequency || '',
+        strength: m?.dosage || '',
+        days: m?.duration ? `${m.duration}` : '',
+        durationUnit: m?.duration_unit || '',
+        remarks: m?.instructions || ''
+      })).filter((m: AiMedicationSuggestion) => !!m.name),
+      advices: (data.medical_advice || []).map((a: any) => a?.v || a).filter(Boolean),
+      tests: (data.tests_to_be_done || []).map((t: any) => t?.test_name || t).filter(Boolean),
+      referrals: (data.referral || []).map((r: any) => ({
+        speciality: r?.referral_to || '',
+        facility: r?.referral_facility || '',
+        priority: '',
+        reason: r?.remark || ''
+      })).filter((r: any) => !!r.speciality),
+      followUp: (data.follow_up || []).filter((f: any) => f?.follow_up_duration).map((f: any) => ({
+        required: f?.follow_up_required,
+        duration: f?.follow_up_duration || '',
+        reason: f?.reason_for_follow_up || ''
+      }))[0] || null
+    };
+  }
+
+  private mapConfidence(value: any): SuggestionLikelihood {
+    if (typeof value === 'string') { return this.mapLikelihood(value); }
+    const confidence = Number(value);
+    if (isNaN(confidence)) { return 'Less'; }
+    const score = confidence > 1 ? confidence / 100 : confidence;
+    if (score >= AI_CONFIDENCE_HIGH) { return 'High'; }
+    if (score >= AI_CONFIDENCE_MODERATE) { return 'Moderate'; }
+    return 'Less';
+  }
+
+  private toReasonList(rationale: any): string[] {
+    if (!rationale) { return []; }
+    if (Array.isArray(rationale)) {
+      return rationale.reduce((acc: string[], r: any) =>
+        acc.concat(typeof r === 'string' ? [r] : Object.values(r || {}) as string[]), []);
+    }
+    return [`${rationale}`];
+  }
+
+  private buildRationale(result: any): string[] {
+    if (result?.summarised_rationale?.length) { return result.summarised_rationale; }
+    if (Array.isArray(result?.rationale)) {
+      return result.rationale.flatMap((r: any) => Object.values(r || {})) as string[];
+    }
+    return [];
+  }
 
   loadCurrentVisit(uuid: string): Observable<CurrentVisitData> {
     return this.visitService.fetchVisitDetails(uuid).pipe(

--- a/src/app/modal-components/video-call/video-call.component.html
+++ b/src/app/modal-components/video-call/video-call.component.html
@@ -109,12 +109,14 @@
                 <img src="assets/svgs/call-end.svg" alt="" />
               </button>
             </div>
+            <div class="window-controls" [class.minimized]="_minimized">
               <button
                 type="button"
                 class="video-ctrl-btn fullscreen-btn"
                 (click)="toggleWindow()"
                 data-test-id="btnToggleWindow"
                 [class.minimized]="_minimized"
+                [title]="_minimized ? 'Maximize' : 'Minimize'"
               >
                 <img
                   src="{{
@@ -125,6 +127,7 @@
                   alt=""
                 />
               </button>
+            </div>
           </div>
           <div class="local-con" [class.d-none]="_minimized">
             <div #localVideo class="local-container"></div>


### PR DESCRIPTION
Replace the demo AI content in the v2 doctor's note with live data from
the aiddx-library services, and fix the video call minimize control.

Diagnosis
- Call /ddx when the doctor's note loads and map the response: conclusion
  to the AI clinical summary, ranked results to the suggestion chips,
  summarised_rationale to the "Why <diagnosis>?" panel, and likelihood to
  the High/Moderate/Less badge
- Send the improve-suggestions text and context chips as notes when the
  doctor asks for updated suggestions

Ayu suggested questions
- Map further_questions to the question cards, splitting the trailing
  guidance into a hint line and hiding the category tag when the API
  returns positional keys
- Load the saved interaction note before requesting a diagnosis, persist
  the answers and refine text back to that note, and re-run the
  suggestions with the saved context, matching v1's behaviour
- Add loading, error and empty states so a pending fetch is
  distinguishable from an empty result

Medication, advice, tests, referral and follow-up
- Call /ttxv1 once a diagnosis is confirmed, and on load when the visit
  already has one, mapping all five sections from the shared response
- Prefill the selected medication row from the suggested dosage,
  frequency, duration and duration unit, and carry the unit through on
  save
- Surface AI suggested advice, tests, referral and follow-up as chips
  that reuse each section's existing add flow
