### PR TITLE
fix: enable preserveSymlinks for local aiddx-library symlink dev loop

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,6 +35,7 @@
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
+            "preserveSymlinks": true,
             "tsConfig": "src/tsconfig.app.json",
             "assets": [
               "src/favicon.ico",


### PR DESCRIPTION
## Summary
- Without `preserveSymlinks`, webpack resolves a symlinked local `node_modules/aiddx-library` (used to dev the plugin against a live webapp) to its real path, which then re-resolves `@angular/material`/`@angular/cdk` upward into the plugin's own `node_modules` — a second, non-ngcc'd Material 12 copy alongside the webapp's processed one, throwing `NG0203` from `MatCommonModule_Factory` and silently killing the AI DDx/TTx panels.
- Sets `preserveSymlinks: true` on the browser builder to keep module resolution scoped to the symlink itself.
- No effect on production/CI builds: those run a fresh `npm install` in a clean container (see `Dockerfile`), which never creates symlinks for dependencies — the flag only does anything when a symlink is actually present in `node_modules`, which today only happens during local plugin dev.

## Test plan
- [x] Verified in the served bundle: exactly one `@angular/material/fesm2015/core.js` copy, zero references to `doctor-ddx-plugin/node_modules`.
- [x] Confirmed local dev loop (`ng build aiddx-library --watch` symlinked into the webapp) rebuilds and hot-reloads end-to-end with no NG0203.