### PR TITLE
chore: bump aiddx-library to v1.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
         "@sjmc11/tourguidejs": "^0.0.17",
-        "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.6",
+        "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.7",
         "angular-calendar": "^0.29.0",
         "angular2-signaturepad": "^4.0.2",
         "bootstrap": "^4.6.2",
@@ -4691,6 +4691,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4706,6 +4707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4721,6 +4723,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4736,6 +4739,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4751,6 +4755,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -4766,6 +4771,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4781,6 +4787,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4796,6 +4803,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4811,6 +4819,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4826,6 +4835,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4841,6 +4851,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4856,6 +4867,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4871,6 +4883,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4886,6 +4899,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -4901,6 +4915,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -4916,6 +4931,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -6439,8 +6455,8 @@
       }
     },
     "node_modules/aiddx-library": {
-      "version": "1.3.6",
-      "resolved": "git+ssh://git@github.com/Intelehealth/intelehealth-doctor-ddx-plugin.git#873de646fa98a138d3abdaa7cdee3d0053b44aa7",
+      "version": "1.3.7",
+      "resolved": "git+ssh://git@github.com/Intelehealth/intelehealth-doctor-ddx-plugin.git#67f9c42cf8683822f53c827ac2a72e79faf5608b",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
     "@sjmc11/tourguidejs": "^0.0.17",
-    "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.6",
+    "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.7",
     "angular-calendar": "^0.29.0",
     "angular2-signaturepad": "^4.0.2",
     "bootstrap": "^4.6.2",


### PR DESCRIPTION
## Summary
Bumps `aiddx-library` from `v1.3.6` to `v1.3.7`, which hides empty medication-detail bullets: dosage / frequency / duration / instructions are each rendered as an `<li>`, so a missing field previously left a bare bullet dot on the suggestion card.

Library change: Intelehealth/intelehealth-doctor-ddx-plugin#2

## Note on the `v1.3.6` reference this replaces
The previous `#v1.3.6` pin was dangling — **no git tag has ever existed on the plugin repo**, on this repo's remote or any fork. A clean `npm install` against a tag ref clones the raw repo, which has no built output (`dist/` is gitignored) and no `main`/`module` entry point, so `require.resolve('aiddx-library')` fails with `MODULE_NOT_FOUND`. Existing working installs were all either a manual local symlink or a stale `node_modules`.

`v1.3.7` is published as a **branch containing the built ng-packagr output**, so `npm install` resolves it correctly.

## Test plan
- [x] `npm install` resolves from `Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.7` to the built package (`fesm2022/aiddx-library.mjs`), version `1.3.7`.
- [x] App compiles successfully against the real installed package (no symlink).
- [x] Bundle contains exactly one `@angular/material` copy and zero plugin-repo module leakage.