### PR TITLE
feat: route AI DDx/TTx via portal wrapper, bump aiddx-library to v1.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
         "@sjmc11/tourguidejs": "^0.0.17",
-        "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.6",
+        "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.8",
         "angular-calendar": "^0.29.0",
         "angular2-signaturepad": "^4.0.2",
         "bootstrap": "^4.6.2",
@@ -4691,6 +4691,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4706,6 +4707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4721,6 +4723,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4736,6 +4739,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4751,6 +4755,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -4766,6 +4771,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4781,6 +4787,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4796,6 +4803,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4811,6 +4819,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4826,6 +4835,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4841,6 +4851,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4856,6 +4867,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4871,6 +4883,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4886,6 +4899,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -4901,6 +4915,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -4916,6 +4931,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -6439,14 +6455,15 @@
       }
     },
     "node_modules/aiddx-library": {
-      "version": "1.3.6",
-      "resolved": "git+ssh://git@github.com/Intelehealth/intelehealth-doctor-ddx-plugin.git#873de646fa98a138d3abdaa7cdee3d0053b44aa7",
+      "version": "1.3.8",
+      "resolved": "git+ssh://git@github.com/Intelehealth/intelehealth-doctor-ddx-plugin.git#eed80639ad7dd00f1df69d6d41d1a818f19394a6",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": "^16.2.0",
         "@angular/core": "^16.2.0",
+        "@angular/forms": "^16.2.0",
         "markdown-it": "^14.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
     "@sjmc11/tourguidejs": "^0.0.17",
-    "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.6",
+    "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.8",
     "angular-calendar": "^0.29.0",
     "angular2-signaturepad": "^4.0.2",
     "bootstrap": "^4.6.2",

--- a/src/app/dashboard/visit-summary/diagnosis/diagnosis.component.html
+++ b/src/app/dashboard/visit-summary/diagnosis/diagnosis.component.html
@@ -136,7 +136,7 @@
             </div>
             <div class="confirm-treatment-wrap" *ngIf="!isMCCUser && isVisitNoteProvider && !visitEnded">
               <button type="button" class="confirm-treatment-btn"
-                [disabled]="isTreatmentLoading || (selectedDiagnoses.length === 0 && existingDiagnosis.length === 0)"
+                [disabled]="isTreatmentDisabled"
                 (click)="confirmAndSuggestTreatment()"
                 data-test-id="btnConfirmSuggestTreatment">
                 <ng-container *ngIf="!isTreatmentLoading">
@@ -265,7 +265,7 @@
       (reportPanelIssue)="openReportIssue('ttx_medication')"
       (reportSuggestionIssue)="onMedicationSuggestionReport($event)"
       [treatmentLoading]="isTreatmentLoading"
-      [treatmentDisabled]="isTreatmentLoading || (selectedDiagnoses.length === 0 && existingDiagnosis.length === 0)"
+      [treatmentDisabled]="isTreatmentDisabled"
       (requestTreatmentPlan)="confirmAndSuggestTreatment()"
       data-test-id="libAillmtxMedicationComponent"></lib-aillmtx-medication>
   </ng-container>

--- a/src/app/dashboard/visit-summary/diagnosis/diagnosis.component.ts
+++ b/src/app/dashboard/visit-summary/diagnosis/diagnosis.component.ts
@@ -410,6 +410,13 @@ export class DiagnosisComponent implements OnInit, OnDestroy, OnChanges {
     return this.aillmddxComponent?.selectedDiagnosis || [];
   }
 
+  /*
+   * Gated on diagnoses actually added to the visit, not Ayu checkbox ticks.
+   */
+  get isTreatmentDisabled(): boolean {
+    return this.isTreatmentLoading || this.existingDiagnosis.length === 0;
+  }
+
   get selectedMedication(): any[] {
     return this.aillmtxMedicationComponent?.selectedMedicine || [];
   }


### PR DESCRIPTION
## Depends on

**Backend PR must merge and deploy first** — Intelehealth/intelehealth-backend-service#546. `aiddx-library` v1.3.8 sends `/ddx` and `/ttxv1` to `environment.mindmapURL`, so without the portal wrapper both calls 404.

## Changes

**`aiddx-library` v1.3.6 → v1.3.8** (`package.json`, `package-lock.json`)

v1.3.8 moves `/ddx` and `/ttxv1` off `environment.base` (direct to `ai-middleware`) onto `environment.mindmapURL` (the authenticated portal wrapper), so the AI service's API key stays server-side. `/ddxfinal` and `/ttxfinal` are unchanged.

It also carries two fixes:
- Report-issue note was silently dropped — `FormsModule` was missing from `AiddxLibraryModule`, so `[(ngModel)]` on the note textarea no-op'd. Runtime-only failure, so the build never caught it.
- Suggestion checkboxes were squashed out of square by long adjacent labels — `.custom-checkbox` had a fixed size but no `flex-shrink: 0`. Fixed across all six panels.

**"Confirm & Suggest Treatment Plan" enablement** (`diagnosis.component.{ts,html}`)

Was enabled by *either* an Ayu checkbox tick or an existing diagnosis:

```
isTreatmentLoading || (selectedDiagnoses.length === 0 && existingDiagnosis.length === 0)
```

Ticking a suggestion isn't the same as committing to it, so the button now gates only on diagnoses actually added to the visit, via a single `isTreatmentDisabled` getter. That expression was duplicated in two places (the button and `[treatmentDisabled]` on the medication panel); both now use the getter, so there is one source of truth.

## Notes

- Already-saved diagnoses still enable the button — `existingDiagnosis` is populated from the visit note on load.
- `confirmAndSuggestTreatment()` still auto-adds ticked-but-unadded suggestions on click. Left as-is here since it changes what gets *saved*, not just what's enabled; worth a follow-up decision.