### PR TITLE
feat(visit-summary-v2): AI issue reporting, confidence %, and searchable medicine/advice inputs

### DIFF
--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
@@ -121,9 +121,14 @@
     <p class="vs2-summary-text" *ngIf="aiSummaryExpanded">{{ aiClinicalSummary }}</p>
   </div>
 
-  <h4 class="vs2-ai-dx-title">
-    <img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Diagnosis
-  </h4>
+  <div class="vs2-ai-dx-head">
+    <h4 class="vs2-ai-dx-title">
+      <img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Diagnosis
+    </h4>
+    <button type="button" class="vs2-report-issue-btn" (click)="openReportIssue('ddx')" title="Report an issue with these suggestions">
+      <img src="assets/svgs/alert-triangle.svg" alt="" width="20" height="20" />
+    </button>
+  </div>
 
   <div class="vs2-ai-panel" *ngIf="aiDiagnosisState === 'loading'">
     <div class="vs2-ai-loading-head">
@@ -165,41 +170,40 @@
       <span class="vs2-dx-chip" *ngFor="let s of aiSuggestions"
         [ngClass]="'vs2-dx-' + s.likelihood.toLowerCase()" [class.vs2-dx-selected]="isDiagnosisSelected(s.name)"
         (click)="toggleAiSuggestion(s)">
-        <mat-icon class="vs2-dx-check" *ngIf="isDiagnosisSelected(s.name)">check</mat-icon>
-        <span class="vs2-dx-dot" *ngIf="!isDiagnosisSelected(s.name)"></span>
+        <mat-icon class="vs2-dx-mark">{{ isDiagnosisSelected(s.name) ? 'check' : 'add' }}</mat-icon>
         <span class="vs2-dx-name">{{ s.name }}</span>
-        <span class="vs2-dx-badge">{{ s.likelihood }} Likely</span>
-        <mat-icon class="vs2-dx-info" (click)="toggleWhy(s, $event)">info_outline</mat-icon>
+        <span class="vs2-dx-badge">
+          {{ s.likelihood }} Likely <span class="vs2-dx-pct" *ngIf="s.confidence !== null">{{ confidenceLabel(s) }}</span>
+        </span>
+        <span class="vs2-dx-info-wrap" *ngIf="s.reasons.length">
+          <mat-icon class="vs2-dx-info" (click)="toggleWhy(s, $event)">info_outline</mat-icon>
+          <span class="vs2-dx-why" [class.vs2-dx-why-open]="whySuggestion === s" (click)="$event.stopPropagation()">
+            <h5>Why {{ s.name }}?</h5>
+            <ul class="vs2-bullet-list">
+              <li *ngFor="let r of s.reasons">{{ r }}</li>
+            </ul>
+          </span>
+        </span>
       </span>
-    </div>
-
-    <div class="vs2-dx-why" *ngIf="whySuggestion">
-      <h5>Why {{ whySuggestion.name }}?</h5>
-      <ul class="vs2-bullet-list">
-        <li *ngFor="let r of whySuggestion.reasons">{{ r }}</li>
-      </ul>
     </div>
   </ng-container>
 
-  <ng-select
-    class="vs2-ng-select vs2-dx-search"
-    [items]="diagnosisResults"
-    [(ngModel)]="selectedDiagnosis"
-    bindLabel="name"
-    [searchable]="true"
-    [clearable]="true"
-    [addTag]="false"
-    [minTermLength]="3"
-    typeToSearchText="Type at least 3 characters"
-    (search)="onDiagnosisSearch($event)"
-    (change)="onDiagnosisPicked($event)"
-    placeholder="Type to search diagnosis">
-  </ng-select>
+  <div class="vs2-dx-search">
+    <mat-icon class="vs2-dx-search-icon">search</mat-icon>
+    <input class="vs2-dx-search-input" type="text" [ngModel]="diagnosisSearchTerm"
+      [ngModelOptions]="{ standalone: true }" (ngModelChange)="onDiagnosisSearch($event)"
+      placeholder="Type to search diagnosis" />
+    <mat-icon class="vs2-dx-search-clear" *ngIf="diagnosisSearchTerm" (click)="clearDiagnosisSearch()">close</mat-icon>
+  </div>
 
-  <div class="vs2-dx-quick-row">
-    <button class="vs2-dx-quick" *ngFor="let q of quickDiagnoses" [class.vs2-dx-quick-on]="isDiagnosisSelected(q)"
-      (click)="toggleQuickDiagnosis(q)">
-      <mat-icon>{{ isDiagnosisSelected(q) ? 'check' : 'add' }}</mat-icon> {{ q }}
+  <div class="vs2-dx-quick-row" *ngIf="diagnosisSearchTerm">
+    <span class="vs2-dx-search-hint" *ngIf="diagnosisSearching">Searching…</span>
+    <span class="vs2-dx-search-hint" *ngIf="!diagnosisSearching && !diagnosisResults.length">
+      No matching diagnosis found
+    </span>
+    <button class="vs2-dx-quick" *ngFor="let r of diagnosisResults" [class.vs2-dx-quick-on]="isDiagnosisSelected(r.name)"
+      (click)="toggleSearchResult(r)">
+      <mat-icon>{{ isDiagnosisSelected(r.name) ? 'check' : 'add' }}</mat-icon> {{ r.name }}
     </button>
   </div>
 
@@ -296,9 +300,14 @@
   </div>
   <div class="vs2-divider"></div>
 
-  <h4 class="vs2-ai-dx-title">
-    <img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Medication
-  </h4>
+  <div class="vs2-ai-dx-head">
+    <h4 class="vs2-ai-dx-title">
+      <img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Medication
+    </h4>
+    <button type="button" class="vs2-report-issue-btn" (click)="openReportIssue('ttx_medication')" title="Report an issue with these suggestions">
+      <img src="assets/svgs/alert-triangle.svg" alt="" width="20" height="20" />
+    </button>
+  </div>
 
   <div class="vs2-ai-panel vs2-ai-empty" *ngIf="medicationPanelState === 'no-diagnosis'">
     <span class="vs2-ai-empty-icon"><img src="assets/svgs/diagnosis.svg" alt="" /></span>
@@ -347,37 +356,37 @@
       <span class="vs2-dx-chip" *ngFor="let s of aiMedicationSuggestions"
         [ngClass]="'vs2-dx-' + s.likelihood.toLowerCase()" [class.vs2-dx-selected]="isMedicineSelected(s.name)"
         (click)="toggleAiMedication(s)">
-        <mat-icon class="vs2-dx-check" *ngIf="isMedicineSelected(s.name)">check</mat-icon>
-        <span class="vs2-dx-dot" *ngIf="!isMedicineSelected(s.name)"></span>
+        <mat-icon class="vs2-dx-mark">{{ isMedicineSelected(s.name) ? 'check' : 'add' }}</mat-icon>
         <span class="vs2-dx-name">{{ isMedicineSelected(s.name) ? s.name : s.label }}</span>
-        <span class="vs2-dx-badge">{{ s.likelihood }} Likely</span>
-        <mat-icon class="vs2-dx-info" (click)="toggleMedicationWhy(s, $event)">info_outline</mat-icon>
+        <span class="vs2-dx-badge">
+          {{ s.likelihood }} Likely <span class="vs2-dx-pct" *ngIf="s.confidence !== null">{{ confidenceLabel(s) }}</span>
+        </span>
+        <span class="vs2-dx-info-wrap" *ngIf="s.reasons.length">
+          <mat-icon class="vs2-dx-info" (click)="toggleMedicationWhy(s, $event)">info_outline</mat-icon>
+          <span class="vs2-dx-why" [class.vs2-dx-why-open]="whyMedication === s" (click)="$event.stopPropagation()">
+            <h5>Why {{ s.name }} ?</h5>
+            <ul class="vs2-bullet-list">
+              <li *ngFor="let r of s.reasons">{{ r }}</li>
+            </ul>
+          </span>
+        </span>
       </span>
-    </div>
-
-    <div class="vs2-dx-why" *ngIf="whyMedication">
-      <h5>Why {{ whyMedication.name }} ?</h5>
-      <ul class="vs2-bullet-list">
-        <li *ngFor="let r of whyMedication.reasons">{{ r }}</li>
-      </ul>
     </div>
   </ng-container>
 
-  <ng-select
-    class="vs2-ng-select vs2-dx-search"
-    [items]="drugOptions"
-    [(ngModel)]="searchedDrug"
-    [addTag]="true"
-    [searchable]="true"
-    [clearable]="true"
-    (change)="onMedicinePicked($event)"
-    placeholder="Type to search medication">
-  </ng-select>
+  <div class="vs2-dx-search">
+    <mat-icon class="vs2-dx-search-icon">search</mat-icon>
+    <input class="vs2-dx-search-input" type="text" [ngModel]="medicineSearchTerm"
+      [ngModelOptions]="{ standalone: true }" (ngModelChange)="onMedicineSearch($event)"
+      placeholder="Type to search medication" />
+    <mat-icon class="vs2-dx-search-clear" *ngIf="medicineSearchTerm" (click)="clearMedicineSearch()">close</mat-icon>
+  </div>
 
-  <div class="vs2-dx-quick-row">
-    <button class="vs2-dx-quick" *ngFor="let q of quickMedicines" [class.vs2-dx-quick-on]="isMedicineSelected(q)"
-      (click)="toggleQuickMedicine(q)">
-      <mat-icon>{{ isMedicineSelected(q) ? 'check' : 'add' }}</mat-icon> {{ q }}
+  <div class="vs2-dx-quick-row" *ngIf="medicineSearchTerm">
+    <span class="vs2-dx-search-hint" *ngIf="!medicineResults.length">Keep typing to search medication</span>
+    <button class="vs2-dx-quick" *ngFor="let r of medicineResults" [class.vs2-dx-quick-on]="isMedicineSelected(r)"
+      (click)="toggleMedicineResult(r)">
+      <mat-icon>{{ isMedicineSelected(r) ? 'check' : 'add' }}</mat-icon> {{ r }}
     </button>
   </div>
 
@@ -479,7 +488,11 @@
   <div class="vs2-divider"></div>
 
   <ng-container *ngIf="aiAdvices.length">
-    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Advice</h4>
+    <div class="vs2-ai-dx-head"><h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Advice</h4>
+    <button type="button" class="vs2-report-issue-btn" (click)="openReportIssue('ttx_advice')" title="Report an issue with these suggestions">
+      <img src="assets/svgs/alert-triangle.svg" alt="" width="20" height="20" />
+    </button>
+    </div>
     <div class="vs2-dx-quick-row">
       <button class="vs2-dx-quick" *ngFor="let a of aiAdvices" [class.vs2-dx-quick-on]="isAdviceSelected(a)"
         (click)="toggleAdvice(a)">
@@ -509,21 +522,18 @@
     </div>
   </div>
 
-  <ng-select
-    class="vs2-ng-select vs2-dx-search"
-    [items]="adviceOptions"
-    [(ngModel)]="newAdviceText"
-    [addTag]="true"
-    [searchable]="true"
-    [clearable]="true"
-    (change)="onAdvicePicked($event)"
-    placeholder="Type to search advice or type custom advice">
-  </ng-select>
+  <div class="vs2-dx-search">
+    <mat-icon class="vs2-dx-search-icon">search</mat-icon>
+    <input class="vs2-dx-search-input" type="text" [ngModel]="adviceSearchTerm"
+      [ngModelOptions]="{ standalone: true }" (ngModelChange)="onAdviceSearch($event)"
+      placeholder="Type to search advice or type custom advice" />
+    <mat-icon class="vs2-dx-search-clear" *ngIf="adviceSearchTerm" (click)="clearAdviceSearch()">close</mat-icon>
+  </div>
 
-  <div class="vs2-dx-quick-row">
-    <button class="vs2-dx-quick" *ngFor="let q of quickAdvices" [class.vs2-dx-quick-on]="isAdviceSelected(q)"
-      (click)="toggleAdvice(q)">
-      <mat-icon>{{ isAdviceSelected(q) ? 'check' : 'add' }}</mat-icon> {{ q }}
+  <div class="vs2-dx-quick-row" *ngIf="adviceSearchTerm">
+    <button class="vs2-dx-quick" *ngFor="let r of adviceResults" [class.vs2-dx-quick-on]="isAdviceSelected(r)"
+      (click)="toggleAdvice(r)">
+      <mat-icon>{{ isAdviceSelected(r) ? 'check' : 'add' }}</mat-icon> {{ r }}
     </button>
   </div>
 
@@ -553,7 +563,11 @@
   <div class="vs2-divider"></div>
 
   <ng-container *ngIf="aiTests.length">
-    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Tests</h4>
+    <div class="vs2-ai-dx-head"><h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Tests</h4>
+    <button type="button" class="vs2-report-issue-btn" (click)="openReportIssue('ttx_test')" title="Report an issue with these suggestions">
+      <img src="assets/svgs/alert-triangle.svg" alt="" width="20" height="20" />
+    </button>
+    </div>
     <div class="vs2-dx-quick-row">
       <button class="vs2-dx-quick" *ngFor="let t of aiTests" [class.vs2-dx-quick-on]="isTestAdded(t)"
         (click)="addAiTest(t)">
@@ -592,7 +606,11 @@
   <div class="vs2-divider"></div>
 
   <ng-container *ngIf="aiReferrals.length">
-    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Referral</h4>
+    <div class="vs2-ai-dx-head"><h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Referral</h4>
+    <button type="button" class="vs2-report-issue-btn" (click)="openReportIssue('ttx_referral')" title="Report an issue with these suggestions">
+      <img src="assets/svgs/alert-triangle.svg" alt="" width="20" height="20" />
+    </button>
+    </div>
     <div class="vs2-dx-quick-row">
       <button class="vs2-dx-quick" *ngFor="let r of aiReferrals" (click)="applyAiReferral(r)">
         <mat-icon>add</mat-icon> {{ r.speciality }}<ng-container *ngIf="r.facility"> - {{ r.facility }}</ng-container>
@@ -674,7 +692,11 @@
   <div class="vs2-divider"></div>
 
   <div class="vs2-ai-followup" *ngIf="aiFollowUp">
-    <h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Follow-up</h4>
+    <div class="vs2-ai-dx-head"><h4 class="vs2-ai-dx-title"><img src="assets/svgs/ayu-new.svg" alt="" /> AI-Suggested Follow-up</h4>
+    <button type="button" class="vs2-report-issue-btn" (click)="openReportIssue('ttx_followup')" title="Report an issue with these suggestions">
+      <img src="assets/svgs/alert-triangle.svg" alt="" width="20" height="20" />
+    </button>
+    </div>
     <button class="vs2-dx-quick" (click)="applyAiFollowUp()">
       <mat-icon>add</mat-icon> {{ aiFollowUp.duration }}<ng-container *ngIf="aiFollowUp.reason"> - {{ aiFollowUp.reason }}</ng-container>
     </button>

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
@@ -763,25 +763,8 @@
   </ng-container>
 </section>
 
-<section id="section-dn-documents" class="vs2-section-card">
-  <div class="vs2-section-title">
-    <img class="vs2-section-icon-img" src="assets/svgs/additional-document-purple.svg" alt="" />
-    <span>Additional documents</span>
-    <mat-icon class="vs2-chevron">expand_less</mat-icon>
-  </div>
-  <div class="vs2-divider"></div>
-
-  <div class="vs2-list-item" *ngFor="let doc of uploadedDocs">
-    <span class="vs2-detail-label">{{ doc.name }}</span>
-    <mat-icon class="vs2-delete-icon">delete_outline</mat-icon>
-  </div>
-
-  <div class="vs2-dropzone">
-    <mat-icon>cloud_upload</mat-icon>
-    <span class="vs2-dropzone-text">Drag &amp; drop files or <a href="javascript:void(0)">Browse</a></span>
-    <span class="vs2-dropzone-hint">Supported formats: Images, JPEG, PNG, GIF, PDF, DOC, Excel, PPT</span>
-  </div>
-  <button class="vs2-btn-primary vs2-mt" (click)="sharePrescription()">
+<div class="vs2-share-row">
+  <button class="vs2-btn-primary" (click)="sharePrescription()">
     {{ prescriptionShared ? 'Update Prescription' : 'Share Prescription' }}
   </button>
-</section>
+</div>

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
@@ -21,7 +21,7 @@ import {
   DIAGNOSIS_SEARCH_DEBOUNCE_MS, DIAGNOSIS_SEARCH_MIN_LENGTH, DIAGNOSIS_STATUSES, DIAGNOSIS_TYPES,
   DOSE_OPTIONS, DRUG_OPTIONS, DURATION_UNIT_OPTIONS, FACILITY_OPTIONS, FREQUENCY_OPTIONS,
   INSTRUCTION_OPTIONS, MEDICINE_SEARCH_MAX_RESULTS, MEDICINE_SEARCH_MIN_LENGTH,
-  ADVICE_SEARCH_MAX_RESULTS, REFERRAL_PRIORITIES,
+  ADVICE_SEARCH_MAX_RESULTS, ADVICE_SEARCH_MIN_LENGTH, REFERRAL_PRIORITIES,
   TIMING_OPTIONS
 } from './doctor-note.constants';
 
@@ -129,8 +129,6 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   followUpTimeSlots: string[] = [];
   readonly quickFollowUpDays = [3, 7, 10, 30];
   minFollowUpDate = new Date().toISOString().slice(0, 10);
-
-  uploadedDocs: { name: string }[] = [];
 
   private provider = getCacheData(true, doctorDetails.PROVIDER);
 
@@ -309,7 +307,15 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   isDiagnosisSelected(name: string): boolean {
+    return this.isDiagnosisPending(name) || this.isDiagnosisAdded(name);
+  }
+
+  private isDiagnosisPending(name: string): boolean {
     return this.selectedDiagnoses.some(d => d.name.toLowerCase() === name.toLowerCase());
+  }
+
+  private isDiagnosisAdded(name: string): boolean {
+    return this.addedDiagnoses.some(d => d.name.toLowerCase() === name.toLowerCase());
   }
 
   toggleAiSuggestion(suggestion: AiDiagnosisSuggestion): void {
@@ -321,6 +327,10 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   private toggleSelectedDiagnosis(name: string, source: 'ai' | 'manual', code = DEFAULT_DIAGNOSIS_CODE): void {
+    if (this.isDiagnosisAdded(name)) {
+      this.coreService.showToast('warning', 'Diagnosis already added, please add another diagnosis.', 'Already Added', 'warning-diagnosis-toast');
+      return;
+    }
     const index = this.selectedDiagnoses.findIndex(d => d.name.toLowerCase() === name.toLowerCase());
     if (index > -1) {
       this.selectedDiagnoses.splice(index, 1);
@@ -342,8 +352,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     if (!this.canWrite()) { return; }
     [...this.selectedDiagnoses].forEach(dx => {
       const payload = { name: dx.name, type: dx.type, status: dx.status, code: dx.code || DEFAULT_DIAGNOSIS_CODE };
-      this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, payload, dx.uuid || undefined).subscribe(res => {
-        this.addedDiagnoses.push({ ...payload, uuid: res?.uuid || dx.uuid || '' });
+      this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, payload).subscribe(res => {
+        this.addedDiagnoses.push({ ...payload, uuid: res?.uuid || '' });
         const index = this.selectedDiagnoses.findIndex(d => d.name === dx.name);
         if (index > -1) { this.selectedDiagnoses.splice(index, 1); }
         this.loadAiTreatment();
@@ -421,16 +431,22 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
 
   editDiagnosis(index: number): void {
     const dx = this.addedDiagnoses[index];
-    if (!dx || this.isDiagnosisSelected(dx.name)) { return; }
-    this.addedDiagnoses.splice(index, 1);
-    this.selectedDiagnoses.push({
-      name: dx.name,
-      code: dx.code || DEFAULT_DIAGNOSIS_CODE,
-      source: 'manual',
-      type: dx.type,
-      status: dx.status,
-      uuid: dx.uuid || ''
-    });
+    if (!dx || this.isDiagnosisPending(dx.name)) { return; }
+    const pullIntoEditor = () => {
+      this.addedDiagnoses.splice(index, 1);
+      this.selectedDiagnoses.push({
+        name: dx.name,
+        code: dx.code || DEFAULT_DIAGNOSIS_CODE,
+        source: 'manual',
+        type: dx.type,
+        status: dx.status
+      });
+    };
+    if (dx.uuid) {
+      this.v2Service.deleteObs(dx.uuid).subscribe(() => pullIntoEditor());
+      return;
+    }
+    pullIntoEditor();
   }
 
   deleteDiagnosis(index: number, uuid?: string): void {
@@ -448,7 +464,15 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   isMedicineSelected(name: string): boolean {
+    return this.isMedicinePending(name) || this.isMedicineAdded(name);
+  }
+
+  private isMedicinePending(name: string): boolean {
     return this.selectedMedicines.some(m => m.drug.toLowerCase() === name.toLowerCase());
+  }
+
+  private isMedicineAdded(name: string): boolean {
+    return this.addedMedicines.some(m => m.drug.toLowerCase() === name.toLowerCase());
   }
 
   toggleAiMedication(suggestion: AiMedicationSuggestion): void {
@@ -466,7 +490,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     const contains = this.drugOptions.filter(d => !d.toLowerCase().startsWith(query) && d.toLowerCase().includes(query));
     this.medicineResults = [...starts, ...contains].slice(0, MEDICINE_SEARCH_MAX_RESULTS);
     if (!this.medicineResults.some(d => d.toLowerCase() === query)) {
-      this.medicineResults.unshift(term.trim());
+      this.medicineResults.push(term.trim());
     }
   }
 
@@ -479,6 +503,10 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   private toggleSelectedMedicine(drug: string, source: 'ai' | 'manual', suggestion?: AiMedicationSuggestion): void {
+    if (this.isMedicineAdded(drug)) {
+      this.coreService.showToast('warning', 'Medicine already added, please add another medicine.', 'Already Added', 'warning-medicine-toast');
+      return;
+    }
     const index = this.selectedMedicines.findIndex(m => m.drug.toLowerCase() === drug.toLowerCase());
     if (index > -1) {
       this.selectedMedicines.splice(index, 1);
@@ -607,7 +635,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   onAdviceSearch(term: string): void {
     this.adviceSearchTerm = term;
     const query = (term || '').trim().toLowerCase();
-    if (!query) {
+    if (query.length < ADVICE_SEARCH_MIN_LENGTH) {
       this.adviceResults = [];
       return;
     }
@@ -615,7 +643,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     const contains = this.adviceOptions.filter(a => !a.toLowerCase().startsWith(query) && a.toLowerCase().includes(query));
     this.adviceResults = [...starts, ...contains].slice(0, ADVICE_SEARCH_MAX_RESULTS);
     if (!this.adviceResults.some(a => a.toLowerCase() === query)) {
-      this.adviceResults.unshift(term.trim());
+      this.adviceResults.push(term.trim());
     }
   }
 

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
@@ -6,6 +6,7 @@ import { doctorDetails } from 'src/config/constant';
 import { getCacheData } from 'src/app/utils/utility-functions';
 import { PatientModel, VisitModel } from 'src/app/model/model';
 import { CoreService } from 'src/app/services/core/core.service';
+import { ReportAiIssueDialogData } from 'src/app/modal-components/report-ai-issue/report-ai-issue.component';
 import {
   DiagnosisOption, DraftAdvice, DraftDiagnosis, DraftMedication, DraftReferral,
   DraftTest, DraftTextItem, VisitSummaryV2Service
@@ -19,7 +20,8 @@ import {
   DEFAULT_DIAGNOSIS_CODE, DEFAULT_DIAGNOSIS_STATUS, DEFAULT_DIAGNOSIS_TYPE, DEFAULT_MEDICINE_DURATION_UNIT,
   DIAGNOSIS_SEARCH_DEBOUNCE_MS, DIAGNOSIS_SEARCH_MIN_LENGTH, DIAGNOSIS_STATUSES, DIAGNOSIS_TYPES,
   DOSE_OPTIONS, DRUG_OPTIONS, DURATION_UNIT_OPTIONS, FACILITY_OPTIONS, FREQUENCY_OPTIONS,
-  INSTRUCTION_OPTIONS, QUICK_ADVICES, QUICK_DIAGNOSES, QUICK_MEDICINES, REFERRAL_PRIORITIES,
+  INSTRUCTION_OPTIONS, MEDICINE_SEARCH_MAX_RESULTS, MEDICINE_SEARCH_MIN_LENGTH,
+  ADVICE_SEARCH_MAX_RESULTS, REFERRAL_PRIORITIES,
   TIMING_OPTIONS
 } from './doctor-note.constants';
 
@@ -40,16 +42,13 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   readonly contextChips = CONTEXT_CHIPS;
   readonly diagnosisTypes = DIAGNOSIS_TYPES;
   readonly diagnosisStatuses = DIAGNOSIS_STATUSES;
-  readonly quickDiagnoses = QUICK_DIAGNOSES;
   readonly drugOptions = DRUG_OPTIONS;
   readonly doseOptions = DOSE_OPTIONS;
   readonly durationUnitOptions = DURATION_UNIT_OPTIONS;
   readonly instructionOptions = INSTRUCTION_OPTIONS;
   readonly frequencyOptions = FREQUENCY_OPTIONS;
-  readonly quickMedicines = QUICK_MEDICINES;
   readonly timingOptions = TIMING_OPTIONS;
   readonly dayOptions = DAY_OPTIONS;
-  readonly quickAdvices = QUICK_ADVICES;
   readonly adviceBundles = ADVICE_BUNDLES;
   readonly facilityOptions = FACILITY_OPTIONS;
   readonly referralPriorities = REFERRAL_PRIORITIES;
@@ -76,21 +75,19 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   aiClinicalSummary = '';
   aiSuggestions: AiDiagnosisSuggestion[] = [];
 
-  selectedDiagnosis: DiagnosisOption | null = null;
+  diagnosisSearchTerm = '';
+  diagnosisSearching = false;
   diagnosisResults: DiagnosisOption[] = [];
   private diagnosisSearch$ = new Subject<string>();
-  newDiagnosisType = DEFAULT_DIAGNOSIS_TYPE;
-  newDiagnosisStatus = DEFAULT_DIAGNOSIS_STATUS;
   addedDiagnoses: DraftDiagnosis[] = [];
-  private editDiagnosisUuid = '';
-  private editDiagnosisIndex = -1;
 
   newNoteText = '';
   outcomeNotes: DraftTextItem[] = [];
 
   aiMedicationState: AiMedicationState = 'ready';
   whyMedication: AiMedicationSuggestion | null = null;
-  searchedDrug: string | null = null;
+  medicineSearchTerm = '';
+  medicineResults: string[] = [];
   selectedMedicines: SelectedMedicine[] = [];
 
   aiMedicationSuggestions: AiMedicationSuggestion[] = [];
@@ -107,7 +104,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   medInstructionText = '';
   medInstructions: DraftTextItem[] = [];
 
-  newAdviceText: string | null = null;
+  adviceSearchTerm = '';
+  adviceResults: string[] = [];
   adviceOptions: string[] = [];
   advices: DraftAdvice[] = [];
   selectedAdvices: string[] = [];
@@ -141,6 +139,26 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     private coreService: CoreService,
     private router: Router
   ) {}
+
+  private getPatientOpenMrsId(): string {
+    const identifiers = (this.patientInfo as any)?.identifiers || [];
+    const idf = identifiers.find((i: any) => i.identifierType?.display === 'OpenMRS ID');
+    return idf?.identifier || '';
+  }
+
+  openReportIssue(aiSurface: ReportAiIssueDialogData['aiSurface'], item?: any): void {
+    const doctor = getCacheData(true, doctorDetails.PROVIDER);
+    this.coreService.openReportAiIssueModal({
+      visitUuid: this.visitUuid || this.visit?.uuid,
+      doctorUuid: doctor?.uuid,
+      patientUuid: this.patientUuid || this.visit?.patient?.uuid,
+      aiSurface,
+      suggestionRef: item?.diagnosis || item?.name || item?.speciality || item?.duration || (typeof item === 'string' ? item : undefined),
+      rawSuggestion: item,
+      doctorName: getCacheData(true, doctorDetails.USER)?.person?.display,
+      patientOpenMrsId: this.getPatientOpenMrsId(),
+    }).subscribe();
+  }
 
   get whatsAppLink(): string | null {
     if (!this.patientPhoneNo) {
@@ -217,7 +235,10 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
       debounceTime(DIAGNOSIS_SEARCH_DEBOUNCE_MS),
       distinctUntilChanged(),
       switchMap(term => term && term.length >= DIAGNOSIS_SEARCH_MIN_LENGTH ? this.v2Service.searchDiagnosis(term) : of([]))
-    ).subscribe(results => { this.diagnosisResults = results; });
+    ).subscribe(results => {
+      this.diagnosisResults = results;
+      this.diagnosisSearching = false;
+    });
 
     this.v2Service.getAdvicesList().subscribe(list => { this.adviceOptions = list; });
     this.v2Service.getTestsList().subscribe(list => { this.testOptions = list; });
@@ -268,8 +289,23 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     return !!(this.patientUuid && this.visitNoteUuid);
   }
 
-  onDiagnosisSearch(event: { term: string }): void {
-    this.diagnosisSearch$.next(event.term);
+  onDiagnosisSearch(term: string): void {
+    this.diagnosisSearchTerm = term;
+    if (!term || term.length < DIAGNOSIS_SEARCH_MIN_LENGTH) {
+      this.diagnosisResults = [];
+      this.diagnosisSearching = false;
+    } else {
+      this.diagnosisSearching = true;
+    }
+    this.diagnosisSearch$.next(term);
+  }
+
+  clearDiagnosisSearch(): void {
+    this.onDiagnosisSearch('');
+  }
+
+  confidenceLabel(suggestion: { confidence: number | null }): string {
+    return suggestion.confidence === null ? '' : `${suggestion.confidence}%`;
   }
 
   isDiagnosisSelected(name: string): boolean {
@@ -280,8 +316,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.toggleSelectedDiagnosis(suggestion.name, 'ai');
   }
 
-  toggleQuickDiagnosis(name: string): void {
-    this.toggleSelectedDiagnosis(name, 'manual');
+  toggleSearchResult(option: DiagnosisOption): void {
+    this.toggleSelectedDiagnosis(option.name, 'manual', option.code || DEFAULT_DIAGNOSIS_CODE);
   }
 
   private toggleSelectedDiagnosis(name: string, source: 'ai' | 'manual', code = DEFAULT_DIAGNOSIS_CODE): void {
@@ -298,12 +334,6 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.whySuggestion = this.whySuggestion === suggestion ? null : suggestion;
   }
 
-  onDiagnosisPicked(option: DiagnosisOption | null): void {
-    if (!option?.name) { return; }
-    this.toggleSelectedDiagnosis(option.name, 'manual', option.code || DEFAULT_DIAGNOSIS_CODE);
-    this.selectedDiagnosis = null;
-  }
-
   removeSelectedDiagnosis(index: number): void {
     this.selectedDiagnoses.splice(index, 1);
   }
@@ -312,8 +342,8 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     if (!this.canWrite()) { return; }
     [...this.selectedDiagnoses].forEach(dx => {
       const payload = { name: dx.name, type: dx.type, status: dx.status, code: dx.code || DEFAULT_DIAGNOSIS_CODE };
-      this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, payload).subscribe(res => {
-        this.addedDiagnoses.push({ ...payload, uuid: res?.uuid || '' });
+      this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, payload, dx.uuid || undefined).subscribe(res => {
+        this.addedDiagnoses.push({ ...payload, uuid: res?.uuid || dx.uuid || '' });
         const index = this.selectedDiagnoses.findIndex(d => d.name === dx.name);
         if (index > -1) { this.selectedDiagnoses.splice(index, 1); }
         this.loadAiTreatment();
@@ -389,42 +419,18 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     });
   }
 
-  addDiagnosis(): void {
-    if (!this.selectedDiagnosis?.name || !this.canWrite()) { return; }
-    const dx = {
-      name: this.selectedDiagnosis.name,
-      type: this.newDiagnosisType,
-      status: this.newDiagnosisStatus,
-      code: this.selectedDiagnosis.code || DEFAULT_DIAGNOSIS_CODE
-    };
-    this.v2Service.saveDiagnosis(this.patientUuid, this.visitNoteUuid, dx, this.editDiagnosisUuid || undefined).subscribe(res => {
-      const item = { ...dx, uuid: res?.uuid || this.editDiagnosisUuid };
-      if (this.editDiagnosisIndex > -1) {
-        this.addedDiagnoses[this.editDiagnosisIndex] = item;
-      } else {
-        this.addedDiagnoses.push(item);
-      }
-      this.cancelDiagnosis();
-    });
-  }
-
   editDiagnosis(index: number): void {
     const dx = this.addedDiagnoses[index];
-    this.selectedDiagnosis = { name: dx.name, code: dx.code || DEFAULT_DIAGNOSIS_CODE };
-    this.diagnosisResults = [this.selectedDiagnosis];
-    this.newDiagnosisType = dx.type;
-    this.newDiagnosisStatus = dx.status;
-    this.editDiagnosisIndex = index;
-    this.editDiagnosisUuid = dx.uuid || '';
-  }
-
-  cancelDiagnosis(): void {
-    this.selectedDiagnosis = null;
-    this.diagnosisResults = [];
-    this.newDiagnosisType = DEFAULT_DIAGNOSIS_TYPE;
-    this.newDiagnosisStatus = DEFAULT_DIAGNOSIS_STATUS;
-    this.editDiagnosisIndex = -1;
-    this.editDiagnosisUuid = '';
+    if (!dx || this.isDiagnosisSelected(dx.name)) { return; }
+    this.addedDiagnoses.splice(index, 1);
+    this.selectedDiagnoses.push({
+      name: dx.name,
+      code: dx.code || DEFAULT_DIAGNOSIS_CODE,
+      source: 'manual',
+      type: dx.type,
+      status: dx.status,
+      uuid: dx.uuid || ''
+    });
   }
 
   deleteDiagnosis(index: number, uuid?: string): void {
@@ -449,7 +455,26 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.toggleSelectedMedicine(suggestion.name, 'ai', suggestion);
   }
 
-  toggleQuickMedicine(name: string): void {
+  onMedicineSearch(term: string): void {
+    this.medicineSearchTerm = term;
+    const query = (term || '').trim().toLowerCase();
+    if (query.length < MEDICINE_SEARCH_MIN_LENGTH) {
+      this.medicineResults = [];
+      return;
+    }
+    const starts = this.drugOptions.filter(d => d.toLowerCase().startsWith(query));
+    const contains = this.drugOptions.filter(d => !d.toLowerCase().startsWith(query) && d.toLowerCase().includes(query));
+    this.medicineResults = [...starts, ...contains].slice(0, MEDICINE_SEARCH_MAX_RESULTS);
+    if (!this.medicineResults.some(d => d.toLowerCase() === query)) {
+      this.medicineResults.unshift(term.trim());
+    }
+  }
+
+  clearMedicineSearch(): void {
+    this.onMedicineSearch('');
+  }
+
+  toggleMedicineResult(name: string): void {
     this.toggleSelectedMedicine(name, 'manual');
   }
 
@@ -476,11 +501,6 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     this.whyMedication = this.whyMedication === suggestion ? null : suggestion;
   }
 
-  onMedicinePicked(drug: string | null): void {
-    if (!drug) { return; }
-    this.toggleSelectedMedicine(drug, 'manual');
-    this.searchedDrug = null;
-  }
 
   cancelMedicineEdit(index: number): void {
     const m = this.selectedMedicines[index];
@@ -584,10 +604,23 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
     }
   }
 
-  onAdvicePicked(value: string | null): void {
-    if (!value) { return; }
-    this.toggleAdvice(value);
-    this.newAdviceText = null;
+  onAdviceSearch(term: string): void {
+    this.adviceSearchTerm = term;
+    const query = (term || '').trim().toLowerCase();
+    if (!query) {
+      this.adviceResults = [];
+      return;
+    }
+    const starts = this.adviceOptions.filter(a => a.toLowerCase().startsWith(query));
+    const contains = this.adviceOptions.filter(a => !a.toLowerCase().startsWith(query) && a.toLowerCase().includes(query));
+    this.adviceResults = [...starts, ...contains].slice(0, ADVICE_SEARCH_MAX_RESULTS);
+    if (!this.adviceResults.some(a => a.toLowerCase() === query)) {
+      this.adviceResults.unshift(term.trim());
+    }
+  }
+
+  clearAdviceSearch(): void {
+    this.onAdviceSearch('');
   }
 
   removeSelectedAdvice(index: number): void {
@@ -610,7 +643,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   }
 
   cancelAdvice(): void {
-    this.newAdviceText = null;
+    this.clearAdviceSearch();
     this.selectedAdvices = [];
     this.openBundle = null;
   }

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
@@ -11,11 +11,13 @@ export const DEFAULT_DIAGNOSIS_CODE = 'NA';
 export const DEFAULT_DIAGNOSIS_TYPE = 'Primary';
 export const DEFAULT_DIAGNOSIS_STATUS = 'Provisional';
 export const DEFAULT_MEDICINE_DURATION_UNIT = 'Days';
+export const MEDICINE_SEARCH_MIN_LENGTH = 2;
+export const MEDICINE_SEARCH_MAX_RESULTS = 8;
+export const ADVICE_SEARCH_MAX_RESULTS = 8;
 
 export const CONTEXT_CHIPS: string[] = ['Pregnancy', 'Travel History', 'Immunocompromised', 'Weight Loss', 'Chronic Disease'];
 export const DIAGNOSIS_TYPES: string[] = ['Primary', 'Secondary'];
 export const DIAGNOSIS_STATUSES: string[] = ['Provisional', 'Confirmed', 'Under Evaluation'];
-export const QUICK_DIAGNOSES: string[] = ['Viral Fever', 'Hypertension', 'UTI', 'Diabetes', 'Pregnancy'];
 
 export const DRUG_OPTIONS: string[] = medicines.map(m => m.name);
 export const DOSE_OPTIONS: string[] = doses.map(d => d.name);
@@ -29,11 +31,8 @@ export const FREQUENCY_OPTIONS: string[] = [
   'Every 30 minutes', 'Every hour', 'Every four hours', 'Every eight hours',
   'Twice daily before meals', 'Twice daily after meals'
 ];
-export const QUICK_MEDICINES: string[] = ['Paracetamol', 'Lisinopril', 'Nitrofurantoin', 'Metformin', 'Prenatal vitamins'];
 export const TIMING_OPTIONS: string[] = ['1 - 0 - 0', '0 - 1 - 0', '0 - 0 - 1', '1 - 0 - 1', '1 - 1 - 1'];
 export const DAY_OPTIONS: string[] = ['3', '5', '7', '10', '15', '30'];
-
-export const QUICK_ADVICES: string[] = ['Light Exercise', 'Drink 2-3 liters of water', 'Use Lukewarm water', 'Follow up in 7 days'];
 
 export const ADVICE_BUNDLES: AdviceBundle[] = [
   {

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.constants.ts
@@ -14,6 +14,7 @@ export const DEFAULT_MEDICINE_DURATION_UNIT = 'Days';
 export const MEDICINE_SEARCH_MIN_LENGTH = 2;
 export const MEDICINE_SEARCH_MAX_RESULTS = 8;
 export const ADVICE_SEARCH_MAX_RESULTS = 8;
+export const ADVICE_SEARCH_MIN_LENGTH = 2;
 
 export const CONTEXT_CHIPS: string[] = ['Pregnancy', 'Travel History', 'Immunocompromised', 'Weight Loss', 'Chronic Disease'];
 export const DIAGNOSIS_TYPES: string[] = ['Primary', 'Secondary'];

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
@@ -1979,6 +1979,12 @@ app-past-visits {
   margin-top: 14px;
 }
 
+.vs2-share-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
 .vs2-btn-row {
   display: flex;
   gap: 12px;

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.scss
@@ -1135,6 +1135,31 @@ app-past-visits {
   }
 }
 
+.vs2-ai-dx-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .vs2-ai-dx-title {
+    margin-bottom: 12px;
+  }
+}
+
+.vs2-report-issue-btn {
+  background: none;
+  border: none;
+  outline: none;
+  padding: 2px 4px;
+  margin-bottom: 12px;
+  cursor: pointer;
+  line-height: 0;
+  opacity: 0.75;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .vs2-ai-panel {
   background: $section-bg;
   border-radius: 12px;
@@ -1260,13 +1285,6 @@ app-past-visits {
   cursor: pointer;
   background: #fff;
 
-  .vs2-dx-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: $grey-text;
-  }
-
   .vs2-dx-badge {
     border-radius: 6px;
     padding: 3px 8px;
@@ -1277,7 +1295,7 @@ app-past-visits {
   }
 
   .vs2-dx-info,
-  .vs2-dx-check {
+  .vs2-dx-mark {
     font-size: 18px;
     width: 18px;
     height: 18px;
@@ -1287,46 +1305,107 @@ app-past-visits {
   &.vs2-dx-high {
     border-color: #bdeedd;
 
-    .vs2-dx-dot { background: $green; }
     .vs2-dx-badge { background: $green-soft; color: #1f9d6e; }
   }
 
   &.vs2-dx-moderate {
     border-color: #f6d9a8;
 
-    .vs2-dx-dot { background: #e79a2b; }
     .vs2-dx-badge { background: #fff4e2; color: #c2760f; }
   }
 
   &.vs2-dx-selected {
     border-color: $green;
 
-    .vs2-dx-check { color: $green; }
+    .vs2-dx-mark { color: $green; }
   }
+}
+
+.vs2-dx-info-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .vs2-dx-why {
-  background: $section-bg;
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 10px);
+  right: -8px;
+  z-index: 5;
+  width: 240px;
+  cursor: default;
+  background: #fff;
+  border: 1px solid $border;
   border-radius: 10px;
-  padding: 14px 18px;
-  margin-bottom: 16px;
+  box-shadow: 0 6px 20px rgba(20, 20, 60, 0.16);
+  padding: 12px 14px;
+
+  &.vs2-dx-why-open {
+    display: block;
+  }
 
   h5 {
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 700;
     color: $purple;
-    margin: 0 0 8px;
+    margin: 0 0 6px;
+  }
+
+  .vs2-bullet-list {
+    margin: 0;
+    padding-left: 16px;
+    font-size: 12px;
+    color: $navy;
   }
 }
 
-.vs2-dx-search {
+.vs2-dx-info-wrap:hover .vs2-dx-why {
   display: block;
+}
+
+.vs2-dx-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: $section-bg;
+  border: 1px solid $border;
+  border-radius: 999px;
+  padding: 0 16px;
+  min-height: 46px;
   margin-bottom: 12px;
 
-  .ng-select-container {
-    background: $section-bg;
-    min-height: 46px;
+  .vs2-dx-search-icon,
+  .vs2-dx-search-clear {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    color: $grey-text;
+    flex: none;
   }
+
+  .vs2-dx-search-clear {
+    cursor: pointer;
+  }
+
+  .vs2-dx-search-input {
+    flex: 1;
+    border: 0;
+    outline: none;
+    background: transparent;
+    font-size: 15px;
+    color: $navy;
+
+    &::placeholder {
+      color: $grey-text;
+    }
+  }
+}
+
+.vs2-dx-search-hint {
+  font-size: 13px;
+  color: $grey-text;
+  align-self: center;
 }
 
 .vs2-dx-quick-row {

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.component.ts
@@ -57,8 +57,7 @@ export class VisitSummaryV2Component implements OnInit, OnDestroy {
     { key: 'dn-advice', label: 'Advice', icon: 'assets/svgs/advice.svg' },
     { key: 'dn-test', label: 'Test', icon: 'assets/svgs/test.svg' },
     { key: 'dn-referral', label: 'Referral-Out', icon: 'assets/svgs/referal.svg' },
-    { key: 'dn-followup', label: 'Follow-up', icon: 'assets/svgs/follow-up.svg' },
-    { key: 'dn-documents', label: 'Additional documents', icon: 'assets/svgs/additional-document-purple.svg' }
+    { key: 'dn-followup', label: 'Follow-up', icon: 'assets/svgs/follow-up.svg' }
   ];
 
   patient: Patient | null = null;

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
@@ -112,6 +112,7 @@ export type SuggestionSource = 'ai' | 'manual';
 export interface AiDiagnosisSuggestion {
   name: string;
   likelihood: SuggestionLikelihood;
+  confidence: number | null;
   reasons: string[];
 }
 
@@ -119,6 +120,7 @@ export interface AiMedicationSuggestion {
   name: string;
   label: string;
   likelihood: SuggestionLikelihood;
+  confidence: number | null;
   reasons: string[];
   timing?: string;
   strength?: string;
@@ -147,6 +149,7 @@ export interface SelectedDiagnosis {
   source: SuggestionSource;
   type: string;
   status: string;
+  uuid?: string;
 }
 
 export interface SelectedMedicine {

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
@@ -149,7 +149,6 @@ export interface SelectedDiagnosis {
   source: SuggestionSource;
   type: string;
   status: string;
-  uuid?: string;
 }
 
 export interface SelectedMedicine {

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.service.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.service.ts
@@ -133,6 +133,7 @@ export class VisitSummaryV2Service {
       suggestions: results.map((r: any) => ({
         name: r?.diagnosis || '',
         likelihood: this.mapLikelihood(r?.likelihood),
+        confidence: this.mapProbability(r?.probability),
         reasons: this.buildRationale(r)
       })).filter((s: AiDiagnosisSuggestion) => !!s.name),
       questions: questions.map((q: any) => {
@@ -147,6 +148,13 @@ export class VisitSummaryV2Service {
         };
       }).filter((q: AyuSuggestedQuestion) => !!q.question)
     };
+  }
+
+  private mapProbability(value: any): number | null {
+    if (value === null || value === undefined || value === '') { return null; }
+    const num = Number(value);
+    if (isNaN(num)) { return null; }
+    return Math.round(num <= 1 ? num * 100 : num);
   }
 
   private mapLikelihood(value: string): SuggestionLikelihood {
@@ -171,6 +179,7 @@ export class VisitSummaryV2Service {
         name: m?.name || '',
         label: m?.name || '',
         likelihood: this.mapConfidence(m?.confidence),
+        confidence: this.mapProbability(m?.confidence),
         reasons: this.toReasonList(m?.rationale),
         timing: m?.frequency || '',
         strength: m?.dosage || '',


### PR DESCRIPTION
- Add "report an issue" action to every AI-suggested section of the doctor
  note (diagnosis, medication, advice, tests, referral, follow-up). 
- Surface model confidence as a percentage on AI diagnosis and medication
  chips.
- Replace the medicine and advice dropdowns with debounced chip-based search
  that filters the bundled lists locally and still allows free-text entry.
- Drop the unused QUICK_DIAGNOSES / QUICK_MEDICINES / QUICK_ADVICES
  constants and simplify the added-diagnosis edit flow to track the row by
  uuid.
