### PR TITLE
fix(visit-summary-v2): block AI diagnosis and treatment calls when required patient details are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ SHOW_CAPTCHA=true/false
 ```
 
 [Disclaimer:] (https://github.com/Intelehealth/Intelehealth-Doctor-WebApp/blob/master/HEALTHCARE%20DISCLAIMER.md)
+
+## AI suggestions: required patient details
+
+The visit summary AI panels (`visit-summary-v2`) call ai-middleware through the portal, which requires `Age`, `Weight (kg)` and `Gender` in the generated case history for both diagnosis and treatment. Weight is only present when the visit has a Vitals encounter, so a visit with no recorded vitals cannot produce AI suggestions.
+
+`VisitSummaryV2Service.missingAiDetails()` mirrors those server rules and is checked before the request is sent. When something is missing the panels show a "Patient Details Required" state naming the missing fields, instead of firing a request that fails validation and surfaces as a generic error. Age and weight must contain a number; gender only has to be present.
+
+Keep `missingAiDetails()` in sync with `_validate_required_demographics` in ai-middleware `models/requests.py` if the required fields change.

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.html
@@ -155,6 +155,17 @@
     </div>
   </div>
 
+  <div class="vs2-ai-panel vs2-ai-empty" *ngIf="aiDiagnosisState === 'missing-details'">
+    <span class="vs2-ai-empty-icon"><img src="assets/svgs/diagnosis.svg" alt="" /></span>
+    <span class="vs2-ai-empty-title">Patient Details Required</span>
+    <span class="vs2-ai-empty-sub">AI-assisted diagnosis needs {{ aiMissingDetailsText }}.<br />Please record the
+      patient's vitals for this visit to continue.</span>
+    <div class="vs2-ai-error-actions">
+      <button class="vs2-btn-outline" (click)="addDiagnosisManually()">Add Diagnosis Manually</button>
+      <button class="vs2-btn-primary" (click)="retryAiDiagnosis()">Try again</button>
+    </div>
+  </div>
+
   <ng-container *ngIf="aiDiagnosisState === 'ready'">
     <div class="vs2-ai-disclaimer">
       <b>Disclaimer:</b> This AI-generated suggestion is intended to support not replace your clinical judgment and may
@@ -305,6 +316,13 @@
     <span class="vs2-ai-empty-title">No Diagnosis Provided</span>
     <span class="vs2-ai-empty-sub">AI-assisted medicines suggestions are based on the diagnosis.<br />Please add the
       required diagnostic details to continue.</span>
+  </div>
+
+  <div class="vs2-ai-panel vs2-ai-empty" *ngIf="medicationPanelState === 'missing-details'">
+    <span class="vs2-ai-empty-icon"><img src="assets/svgs/diagnosis.svg" alt="" /></span>
+    <span class="vs2-ai-empty-title">Patient Details Required</span>
+    <span class="vs2-ai-empty-sub">AI-assisted medication needs {{ aiMissingDetailsText }}.<br />Please record the
+      patient's vitals for this visit to continue.</span>
   </div>
 
   <div class="vs2-ai-panel" *ngIf="medicationPanelState === 'loading'">

--- a/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
+++ b/src/app/dashboard/visit-summary-v2/doctor-note/doctor-note.component.ts
@@ -12,7 +12,7 @@ import {
 } from '../visit-summary-v2.service';
 import {
   AdviceBundle, AiDiagnosisState, AiDiagnosisSuggestion, AiFollowUp, AiMedicationState, AiMedicationSuggestion,
-  AyuSuggestedQuestion, SelectedDiagnosis, SelectedMedicine
+  AiMissingDetailsError, AyuSuggestedQuestion, SelectedDiagnosis, SelectedMedicine
 } from '../visit-summary-v2.models';
 import {
   ADVICE_BUNDLES, CONTEXT_CHIPS, DAY_OPTIONS,
@@ -66,6 +66,7 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
   hasEnoughInfo = true;
 
   aiDiagnosisState: AiDiagnosisState = 'loading';
+  aiMissingDetails: string[] = [];
   aiSummaryExpanded = false;
   improveExpanded = true;
   improveContextText = '';
@@ -334,10 +335,19 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
         this.aiFollowUp = result.followUp;
         this.aiMedicationState = 'ready';
       },
-      error: () => {
-        this.aiMedicationState = 'error';
+      error: err => {
+        this.aiMissingDetails = this.detailsFromError(err);
+        this.aiMedicationState = this.aiMissingDetails.length ? 'missing-details' : 'error';
       }
     });
+  }
+
+  private detailsFromError(err: unknown): string[] {
+    return err instanceof AiMissingDetailsError ? err.missing : [];
+  }
+
+  get aiMissingDetailsText(): string {
+    return this.aiMissingDetails.join(', ');
   }
 
   isContextChipOn(chip: string): boolean {
@@ -383,8 +393,9 @@ export class DoctorNoteComponent implements OnChanges, OnInit {
         this.ayuSuggestedQuestions = result.questions;
         this.aiDiagnosisState = 'ready';
       },
-      error: () => {
-        this.aiDiagnosisState = 'error';
+      error: err => {
+        this.aiMissingDetails = this.detailsFromError(err);
+        this.aiDiagnosisState = this.aiMissingDetails.length ? 'missing-details' : 'error';
       }
     });
   }

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.models.ts
@@ -101,9 +101,16 @@ export interface Patient {
   other: DetailRow[];
 }
 
-export type AiDiagnosisState = 'loading' | 'error' | 'ready';
+export type AiDiagnosisState = 'loading' | 'error' | 'missing-details' | 'ready';
 
-export type AiMedicationState = 'loading' | 'error' | 'no-diagnosis' | 'ready';
+export type AiMedicationState = 'loading' | 'error' | 'missing-details' | 'no-diagnosis' | 'ready';
+
+export class AiMissingDetailsError extends Error {
+  constructor(public readonly missing: string[]) {
+    super(`Missing patient details required for AI suggestions: ${missing.join(', ')}`);
+    this.name = 'AiMissingDetailsError';
+  }
+}
 
 export type SuggestionLikelihood = 'High' | 'Moderate' | 'Less';
 

--- a/src/app/dashboard/visit-summary-v2/visit-summary-v2.service.ts
+++ b/src/app/dashboard/visit-summary-v2/visit-summary-v2.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { EMPTY, forkJoin, Observable, of } from 'rxjs';
+import { EMPTY, forkJoin, Observable, of, throwError } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -18,11 +18,19 @@ import { VisitSummaryHelperService } from 'src/app/services/visit-summary-helper
 import { AppConfigService } from 'src/app/services/app-config.service';
 import { AiddxService, AiTxService } from 'aiddx-library';
 import {
-  AiDiagnosisResult, AiDiagnosisSuggestion, AiMedicationSuggestion, AiTreatmentResult, AyuSuggestedQuestion,
-  ComplaintDetail, DetailRow, DocItem, Patient, PastVisit, PrescriptionData, SuggestionLikelihood,
-  SymptomGroup, TimelineGroup, VitalCell
+  AiDiagnosisResult, AiDiagnosisSuggestion, AiMedicationSuggestion, AiMissingDetailsError, AiTreatmentResult,
+  AyuSuggestedQuestion, ComplaintDetail, DetailRow, DocItem, Patient, PastVisit, PrescriptionData,
+  SuggestionLikelihood, SymptomGroup, TimelineGroup, VitalCell
 } from './visit-summary-v2.models';
 import { AI_CONFIDENCE_HIGH, AI_CONFIDENCE_MODERATE } from './doctor-note/doctor-note.constants';
+
+const AI_REQUIRED_DETAILS: { label: string; numeric: boolean }[] = [
+  { label: 'Age', numeric: true },
+  { label: 'Weight (kg)', numeric: true },
+  { label: 'Gender', numeric: false }
+];
+
+const AI_UNSPECIFIED = /\b(not\s+specified|unknown|none|n\/?a)\b/i;
 
 export interface DraftDiagnosis { name: string; type: string; status: string; code: string; uuid: string; }
 export interface DiagnosisOption { name: string; code: string; }
@@ -118,8 +126,28 @@ export class VisitSummaryV2Service {
       : this.visitService.postAttribute(visitUuid, payload);
   }
 
+  missingAiDetails(caseText: string): string[] {
+    return AI_REQUIRED_DETAILS
+      .filter(({ label, numeric }) => {
+        const value = this.extractDetail(caseText, label);
+        if (!value) { return true; }
+        return numeric && (AI_UNSPECIFIED.test(value) || !/\d/.test(value));
+      })
+      .map(({ label }) => label);
+  }
+
+  private extractDetail(caseText: string, label: string): string {
+    const key = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = new RegExp(`\\b${key}\\s*[:=-]\\s*([^\\n\\r,;]+)`, 'i').exec(caseText || '');
+    return (match?.[1] || '').trim();
+  }
+
   loadAiDiagnosis(patientInfo: PatientModel, visit: VisitModel, notes = '', prescriptionShared = false): Observable<AiDiagnosisResult> {
     const casehistory = this.aiddxService.getDDxPayload(patientInfo, visit, notes);
+    const missing = this.missingAiDetails(casehistory);
+    if (missing.length) {
+      return throwError(() => new AiMissingDetailsError(missing));
+    }
     return this.aiddxService.getAIDiagnosis(casehistory, visit?.uuid, prescriptionShared).pipe(
       map((res: any) => this.buildAiDiagnosisResult(res))
     );
@@ -158,6 +186,10 @@ export class VisitSummaryV2Service {
 
   loadAiTreatment(patientInfo: PatientModel, visit: VisitModel, diagnosis: string, prescriptionShared = false): Observable<AiTreatmentResult> {
     const casehistory = this.aiTxService.getTxPayload(patientInfo, visit);
+    const missing = this.missingAiDetails(casehistory);
+    if (missing.length) {
+      return throwError(() => new AiMissingDetailsError(missing));
+    }
     this.aiTxService.clearCache();
     return this.aiTxService.getAITTx(casehistory, diagnosis, visit?.uuid, prescriptionShared).pipe(
       map((res: any) => this.buildAiTreatmentResult(res))


### PR DESCRIPTION
## Why

A visit with no recorded vitals cannot produce AI suggestions, but the UI gave no way to learn that. ai-middleware requires `Age`, `Weight (kg)` and `Gender` in the case history, and weight is only emitted when the visit has a Vitals encounter — so the request fails pydantic validation with a 422 the webapp can't parse, falling through to the generic "We couldn't generate AI Diagnosis suggestions. There was a temporary issue on our end."

That message is wrong twice over: it is not temporary, and retrying cannot help. Diagnosing one real occurrence took hours because nothing surfaced the actual cause.

This affects **both** AI surfaces — `TTXRequest.validate_case` runs the same `_validate_required_demographics` as `DDXRequest` — so it is fixed once, for both.

## What changed

- `VisitSummaryV2Service.missingAiDetails()` mirrors the server's validation rules and runs before the request is sent, for diagnosis and treatment alike.
- Both paths reject with a typed `AiMissingDetailsError` carrying the missing field names, rather than issuing a request known to fail.
- New `missing-details` panel state naming what is missing ("AI-assisted diagnosis needs Weight (kg)") and pointing at recording vitals, alongside the existing manual-entry escape hatch.

## Matching the server exactly

The client mirrors a subtlety worth noting: the unspecified-value check applies only to numeric fields, so `Gender: Not specified` is legitimately accepted while `Age: Not specified` is not. Verified against the live middleware — every client decision matches the server's actual outcome:

| Case history | Server | Client |
|---|---|---|
| no vitals (the reported failure) | 422 | blocks — `Weight (kg)` |
| `Weight (kg): 62` | 200 | allows |
| `Weight: 62.0 Kg` | 422 | blocks — `Weight (kg)` |
| Vitals block, `Weight (kg)` label | 200 | allows |
| Vitals block, bare `Weight` label | 422 | blocks — `Weight (kg)` |
| `Weight (kg): Not specified` | 422 | blocks — `Weight (kg)` |
| `Gender: Not specified` | 200 | allows |
| `Age: Not specified` | 422 | blocks — `Age` |

The label must be exactly `Weight (kg)`, which is what the OpenMRS concept display returns, so `${concept.display}: ${value}` from aiddx-library already produces the passing form.

## Testing

AOT build clean. Pre-existing `tsc` errors in `dist/` and `.spec.ts` files are untouched; the production build cannot run locally because `src/environments/environment.prod.ts` is a gitignored empty file.

## Related

Intelehealth/intelehealth-backend-service#548 makes the portal's own error handling legible for the same failure. The two are independent and can merge in either order.
